### PR TITLE
Add options to LIME main script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ CPPFLAGS	= -I${PREFIX}/include \
 		  -I${PREFIX}/src \
 		  -I${HOME}/include \
 		  -I/opt/local/include \
-		  -I/sw//include
+		  -I/sw//include \
+	          ${EXTRACPPFLAGS}
 
 ifdef OLD_QHULL
 	QHULL   = qhull

--- a/doc/usermanual.rst
+++ b/doc/usermanual.rst
@@ -114,7 +114,8 @@ completion, the user is prompted to press a key which will bring the
 terminal window back. It is possible to run LIME in silent mode, that
 is, without any output in the terminal window. This is done by setting
 the silent flag to 1 (the default setting is 0) in the file
-LimePackage/src/lime.h.
+LimePackage/src/lime.h. LIME also accepts several
+:ref:`command line options <lime-options>`.
 
 The inner workings of LIME
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -149,6 +150,35 @@ When the solution has converged, the code will ray-trace the model to
 obtain an image. Ray-tracing is done for each user- defined image in
 turn. At the end of the ray-tracing, FITS files will be written to the
 disk at the code will clean up the memory and terminate.
+
+.. _lime-options:
+
+Command line options
+--------------------
+
+.. note::
+
+   Starting with LIME 1.5, command line options can be used to change
+   LIME default behavior without editing the source code.
+
+LIME accepts several command line options:
+
+.. option:: -V
+
+   Display version information
+
+.. option:: -h
+
+   Display help message
+
+.. option:: -f
+
+   Use fast exponential computation. When this option is set, LIME
+   uses a lookup-table replacement for the exponential function, which
+   however (due to cunning use of the properties of the function)
+   returns a value with full floating-point precision, indeed with
+   better precision than that for much of the range. Use of this
+   option reduces the run time by 25%.
 
 Setting up models
 -----------------

--- a/lime
+++ b/lime
@@ -15,6 +15,7 @@ function usage {
     echo "Options:"
     echo "   -V     Display version information"
     echo "   -h     Display this message"
+    echo "   -f     Use fast exponential computation"
     echo ""
     echo "See <http://lime.readthedocs.org> for more information."
     echo "Report bugs to <http://github.com/lime-rt/lime/issues>."
@@ -24,7 +25,8 @@ function tip {
     echo "Try 'lime -h' for more information."
 }
 
-options="Vh"
+options="Vhf"
+cpp_flags=""
 
 while getopts ${options} opt; do
     case $opt in
@@ -35,6 +37,10 @@ while getopts ${options} opt; do
 	h)
 	    usage
 	    exit 0
+	    ;;
+	f)
+	    cpp_flags+="-DFASTEXP"
+	    shift $((OPTIND-1))
 	    ;;
 	\?)
 	    tip
@@ -50,7 +56,7 @@ fi
 
 export WORKDIR=$PWD
 cd $PATHTOLIME
-make MODELS=$WORKDIR/$1 TARGET=$WORKDIR/lime_$$.x
+make EXTRACPPFLAGS="${cpp_flags}" MODELS=$WORKDIR/$1 TARGET=$WORKDIR/lime_$$.x
 make clean
 cd $WORKDIR
 ./lime_$$.x

--- a/lime
+++ b/lime
@@ -1,11 +1,58 @@
 #!/bin/bash -e
-export WORKDIR=$PWD
+# lime -- LIME main script
 
+function version {
+    echo "This is LIME, The versatile line modeling engine, Ver.1.31"
+    echo "Copyright 2006--2014, Christian Brinch <brinch@nbi.dk>"
+}
+
+function usage {
+    echo "Usage: lime [OPTION] [[FILE]]"
+    echo " "
+    echo "Arguments:"
+    echo "   FILE   C model file"
+    echo " "
+    echo "Options:"
+    echo "   -V     Display version information"
+    echo "   -h     Display this message"
+    echo ""
+    echo "See <http://lime.readthedocs.org> for more information."
+    echo "Report bugs to <http://github.com/lime-rt/lime/issues>."
+}
+
+function tip {
+    echo "Try 'lime -h' for more information."
+}
+
+options="Vh"
+
+while getopts ${options} opt; do
+    case $opt in
+	V)
+	    version
+	    exit 0
+	    ;;
+	h)
+	    usage
+	    exit 0
+	    ;;
+	\?)
+	    tip
+	    exit 1
+	    ;;
+    esac
+done
+if [ $# -ne 1 ]; then
+    echo "Invalid number of arguments"
+    tip
+    exit 1
+fi
+
+export WORKDIR=$PWD
 cd $PATHTOLIME
 make MODELS=$WORKDIR/$1 TARGET=$WORKDIR/lime_$$.x
 make clean
 cd $WORKDIR
 ./lime_$$.x
 rm -rf lime_$$.x
-exit
-
+exit 0


### PR DESCRIPTION
This PR adds options to the LIME main script.This allows to set options (verbose, no curse, fast exponential) without changing variables in the `Makefile`.