### PR TITLE
Improved grid building and VTK output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ SRCS    = src/aux.c src/messages.c src/grid.c src/LTEsolution.c   \
 		  src/popsout.c src/predefgrid.c src/ratranInput.c      \
           src/raytrace.c src/smooth.c src/sourcefunc.c          \
 		  src/stateq.c src/statistics.c src/magfieldfit.c       \
-		  src/stokesangles.c src/writefits.c src/weights.c      \
+		  src/stokesangles.c src/writefits.c       \
 		  src/velospline.c src/getclosest.c  \
 		  src/tcpsocket.c src/defaults.c src/fastexp.c
 MODELS  = model.c
@@ -64,7 +64,7 @@ OBJS    = src/aux.o src/messages.o src/grid.o src/LTEsolution.o   \
 		  src/popsout.o src/predefgrid.o src/raytrace.o         \
 		  src/ratranInput.o src/smooth.o src/sourcefunc.o       \
 		  src/stateq.o src/statistics.o src/magfieldfit.o       \
-		  src/stokesangles.o src/writefits.o src/weights.o      \
+		  src/stokesangles.o src/writefits.o       \
 		  src/velospline.o src/getclosest.o  \
 		  src/tcpsocket.o src/defaults.o src/fastexp.o
 MODELO 	= src/model.o

--- a/example/model.c
+++ b/example/model.c
@@ -23,7 +23,7 @@ input(inputPars *par, image *img, region *rgn){
   par->dust				= "jena_thin_e6.tab";
   par->moldatfile[0] 	= "hco+@xpol.dat";
   par->antialias		= 4;
-  par->sampling			= 2; // log distr. for radius, directions distr. uniformly on a sphere.
+  par->sampling			= 0; // log distr. for radius, directions distr. uniformly on a sphere.
   par->lte_only         = 0;
 
   par->outputfile 		= "populations.pop";
@@ -33,7 +33,6 @@ input(inputPars *par, image *img, region *rgn){
   /*
    * Spatial regions
    */
-
   rgn[0].crdType       = 0;
   rgn[0].sampling      = 0;
   rgn[0].xmin          = 0.5*AU;

--- a/example/model.c
+++ b/example/model.c
@@ -24,7 +24,7 @@ input(inputPars *par, image *img, region *rgn){
   par->moldatfile[0] 	= "hco+@xpol.dat";
   par->antialias		= 4;
   par->sampling			= 2; // log distr. for radius, directions distr. uniformly on a sphere.
-  par->lte_only         = 1;
+  par->lte_only         = 0;
 
   par->outputfile 		= "populations.pop";
   par->binoutputfile 	= "restart.pop";

--- a/example/model.c
+++ b/example/model.c
@@ -146,5 +146,26 @@ velocity(double x, double y, double z, double *vel){
 }
 
 /******************************************************************************/
+int
+pointEvaluation(inputPars *par,double ran, double x, double y, double z){
+  double weight1, weight2, val[99],normalizer=0.0,totalDensity=0.0;
+  int i;
 
+  density(par->minScale,par->minScale,par->minScale,val);
+  for (i=0;i<par->collPart;i++) normalizer += val[i];
+  if (normalizer<=0.){
+    if(!silent) bail_out("Error: Sum of reference densities equals 0");
+    exit(1);
+  }
+  //abundance(par->minScale,par->minScale,par->minScale,val2);
+  density(x,y,z,val);
+  for (i=0;i<par->collPart;i++) totalDensity += val[i];
+  //abundance(x,y,z,val2);
+  weight1=pow(totalDensity/normalizer,0.2);
 
+  weight2=0.;
+
+  if(ran < weight1 || ran < weight2) return 1;
+  else return 0;
+}
+/******************************************************************************/

--- a/src/aux.c
+++ b/src/aux.c
@@ -65,11 +65,10 @@ parseInput(inputPars *par, image **img, molData **m, region **rgn){
   }
   *img=realloc(*img, sizeof(image)*par->nImages);
 
-  id=0;
+  id=-1;
   while((*rgn)[++id].crdType!=-1);
   par->nRegions=id;
   if(par->nRegions==0) {
-      if(!silent) bail_out("Warning: no spatial region defined\\ I take everything from minScale to radius");
       *rgn=realloc(*rgn, sizeof(region)*1);
   } else {
       *rgn=realloc(*rgn, sizeof(region)*par->nRegions);
@@ -110,20 +109,23 @@ parseInput(inputPars *par, image **img, molData **m, region **rgn){
     (*img)[i].bandwidth=-1.;
   }
 
-  for(i=0;i<par->nRegions;i++){
-      (*rgn)[i].crdType=-1;
-      (*rgn)[i].sampling=-1;
-      (*rgn)[i].nPoints=-1;
-      (*rgn)[i].xmin=0.;
-      (*rgn)[i].xmax=0.;
-      (*rgn)[i].ymin=0.;
-      (*rgn)[i].ymax=0.;
-      (*rgn)[i].zmin=0.;
-      (*rgn)[i].zmax=0.;
-      (*rgn)[i].xref=0.;
-      (*rgn)[i].yref=0.;
-      (*rgn)[i].zref=0.;
+  if( par->nRegions>0 ){
+      for(i=0;i<par->nRegions;i++){
+          (*rgn)[i].crdType=-1;
+          (*rgn)[i].sampling=-1;
+          (*rgn)[i].nPoints=-1;
+          (*rgn)[i].xmin=0.;
+          (*rgn)[i].xmax=0.;
+          (*rgn)[i].ymin=0.;
+          (*rgn)[i].ymax=0.;
+          (*rgn)[i].zmin=0.;
+          (*rgn)[i].zmax=0.;
+          (*rgn)[i].xref=0.;
+          (*rgn)[i].yref=0.;
+          (*rgn)[i].zref=0.;
+      }
   }
+
   input(par,*img, *rgn);
 
   if(par->nRegions==0) {
@@ -132,10 +134,10 @@ parseInput(inputPars *par, image **img, molData **m, region **rgn){
       (*rgn)[0].sampling=par->sampling;
       (*rgn)[0].xmin=par->minScale;
       (*rgn)[0].xmax=par->radius;
-      (*rgn)[0].ymin=0;
+      (*rgn)[0].ymin=0.;
       (*rgn)[0].ymax=PI;
-      (*rgn)[0].ymin=0;
-      (*rgn)[0].ymax=2.0*PI;
+      (*rgn)[0].zmin=0.;
+      (*rgn)[0].zmax=2.0*PI;
       (*rgn)[0].xref=par->minScale*1.5;
       (*rgn)[0].yref=PI/2.;
       (*rgn)[0].zref=0.;

--- a/src/aux.c
+++ b/src/aux.c
@@ -277,7 +277,7 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
 }
 
 void
-freeInput( inputPars *par, image* img, molData* mol )
+freeInput( inputPars *par, image* img, molData* mol, region* rgn)
 {
   int i,id;
   if( mol!= 0 )
@@ -361,6 +361,10 @@ freeInput( inputPars *par, image* img, molData* mol )
   if( par->moldatfile != NULL )
     {
       free(par->moldatfile);
+    }
+  if( rgn != NULL )
+    {
+      free(rgn);
     }
 }
 

--- a/src/aux.c
+++ b/src/aux.c
@@ -14,7 +14,7 @@
 
 
 void
-parseInput(inputPars *par, image **img, molData **m){
+parseInput(inputPars *par, image **img, molData **m, region **rgn){
   FILE *fp;
   int i,id;
   double BB[3];
@@ -47,7 +47,15 @@ parseInput(inputPars *par, image **img, molData **m){
     (*img)[id].filename=NULL;
     par->moldatfile[id]=NULL;
   }
-  input(par, *img);
+  /* Allocate space for spatial regions */
+
+  (*rgn)=malloc(sizeof(region)*MAX_REGIONS);
+  for(id=0;id<MAX_REGIONS;id++){
+      (*rgn)[id].crdType=-1;
+  }
+
+  input(par, *img, *rgn);
+
   id=-1;
   while((*img)[++id].filename!=NULL);
   par->nImages=id;
@@ -55,9 +63,18 @@ parseInput(inputPars *par, image **img, molData **m){
     if(!silent) bail_out("Error: no images defined");
     exit(1);
   }
-
   *img=realloc(*img, sizeof(image)*par->nImages);
 
+  id=0;
+  while((*rgn)[++id].crdType!=-1);
+  par->nRegions=id;
+  if(par->nRegions==0) {
+      if(!silent) bail_out("Warning: no spatial region defined\\ I take everything from minScale to radius");
+      *rgn=realloc(*rgn, sizeof(region)*1);
+  } else {
+      *rgn=realloc(*rgn, sizeof(region)*par->nRegions);
+      refresh();
+  }
   id=-1;
   while(par->moldatfile[++id]!=NULL);
   par->nSpecies=id;
@@ -92,7 +109,43 @@ parseInput(inputPars *par, image **img, molData **m){
     (*img)[i].freq=-1.;
     (*img)[i].bandwidth=-1.;
   }
-  input(par,*img);
+
+  for(i=0;i<par->nRegions;i++){
+      (*rgn)[i].crdType=-1;
+      (*rgn)[i].sampling=-1;
+      (*rgn)[i].nPoints=-1;
+      (*rgn)[i].xmin=0.;
+      (*rgn)[i].xmax=0.;
+      (*rgn)[i].ymin=0.;
+      (*rgn)[i].ymax=0.;
+      (*rgn)[i].zmin=0.;
+      (*rgn)[i].zmax=0.;
+      (*rgn)[i].xref=0.;
+      (*rgn)[i].yref=0.;
+      (*rgn)[i].zref=0.;
+  }
+  input(par,*img, *rgn);
+
+  if(par->nRegions==0) {
+      par->nRegions=1;
+      (*rgn)[0].crdType=0;
+      (*rgn)[0].sampling=par->sampling;
+      (*rgn)[0].xmin=par->minScale;
+      (*rgn)[0].xmax=par->radius;
+      (*rgn)[0].ymin=0;
+      (*rgn)[0].ymax=PI;
+      (*rgn)[0].ymin=0;
+      (*rgn)[0].ymax=2.0*PI;
+      (*rgn)[0].xref=par->minScale*1.5;
+      (*rgn)[0].yref=PI/2.;
+      (*rgn)[0].zref=0.;
+      (*rgn)[0].nPoints=par->pIntensity;
+  } else {
+      par->pIntensity = 0;
+      for (i=0;i<par->nRegions;i++){
+          par->pIntensity += (*rgn)[i].nPoints;
+      }
+  }
 
   if(par->nThreads == 0){ // Hmm. Really ought to have a separate boolean parameter.
     par->nThreads = NTHREADS;

--- a/src/grid.c
+++ b/src/grid.c
@@ -325,12 +325,7 @@ write_VTK_unstructured_Points(inputPars *par, struct grid *g){
   }
   fprintf(fp,"VECTORS velocity float\n");
   for(i=0;i<par->ncell;i++){
-    length=sqrt(g[i].vel[0]*g[i].vel[0]+g[i].vel[1]*g[i].vel[1]+g[i].vel[2]*g[i].vel[2]);
-    if(length > 0.){
-      fprintf(fp, "%e %e %e\n", g[i].vel[0]/length,g[i].vel[1]/length,g[i].vel[2]/length);
-    } else {
-      fprintf(fp, "%e %e %e\n", g[i].vel[0],g[i].vel[1],g[i].vel[2]);
-    }
+    fprintf(fp, "%e %e %e\n", g[i].vel[0],g[i].vel[1],g[i].vel[2]);
   }
 
   fclose(fp);

--- a/src/grid.c
+++ b/src/grid.c
@@ -305,7 +305,7 @@ write_VTK_unstructured_Points(inputPars *par, struct grid *g){
   qh_memfreeshort (&curlong, &totlong);
   fprintf(fp,"\nCELL_TYPES %d\n",l);
   for(i=0;i<l;i++){
-    fprintf(fp, "10\n");
+    fprintf(fp, "9\n");
   }
   fprintf(fp,"POINT_DATA %d\n",par->ncell);
   fprintf(fp,"SCALARS H2_density float 1\n");

--- a/src/grid.c
+++ b/src/grid.c
@@ -565,7 +565,7 @@ buildGrid(inputPars *par, struct grid *g, region *rgn){
                   g[ip].dir  = malloc(sizeof(point)*1);
                   g[ip].ds   = malloc(sizeof(point)*1);
                   g[ip].neigh = malloc(sizeof(int)*1);
-                  if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
+                  if(!silent) progressbar((double) ip/((double)par->pIntensity-1), 4);
 
               } else if (rgn[i].sampling==1) {
                   xmin = rgn[i].xmin;
@@ -598,7 +598,7 @@ buildGrid(inputPars *par, struct grid *g, region *rgn){
                   g[ip].dir  = malloc(sizeof(point)*1);
                   g[ip].ds   = malloc(sizeof(point)*1);
                   g[ip].neigh = malloc(sizeof(int)*1);
-                  if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
+                  if(!silent) progressbar((double) ip/((double)par->pIntensity-1), 4);
               } else {
                   if(!silent) bail_out("Don't know how to sample model");
                   exit(1);
@@ -631,7 +631,7 @@ buildGrid(inputPars *par, struct grid *g, region *rgn){
                   g[ip].dir  = malloc(sizeof(point)*1);
                   g[ip].ds   = malloc(sizeof(point)*1);
                   g[ip].neigh = malloc(sizeof(int)*1);
-                  if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
+                  if(!silent) progressbar((double) ip/((double)par->pIntensity-1), 4);
               } else {
                   if (!silent) bail_out("If the region boundares are set in cartesian coordinates only sampling=1 is allowed");
                   exit(1);

--- a/src/grid.c
+++ b/src/grid.c
@@ -515,13 +515,16 @@ getMass(inputPars *par, struct grid *g, const gsl_rng *ran){
 
 
 void
-buildGrid(inputPars *par, struct grid *g){
+buildGrid(inputPars *par, struct grid *g, region *rgn){
   double lograd;		/* The logarithm of the model radius		*/
   double logmin;	    /* Logarithm of par->minScale				*/
   double r,theta,phi,sinPhi,x,y,z,semiradius;	/* Coordinates								*/
   double temp;
   int k=0,i;            /* counters									*/
   int flag;
+  int ip, j;
+  double xmin, xmax, ymin, ymax ; /* Coordinate boundaries */
+  double cos_theta, sin_theta ;
 
   gsl_rng *ran = gsl_rng_alloc(gsl_rng_ranlxs2);	/* Random number generator */
 #ifdef TEST
@@ -530,65 +533,189 @@ buildGrid(inputPars *par, struct grid *g){
   gsl_rng_set(ran,time(0));
 #endif  
   
-  lograd=log10(par->radius);
-  logmin=log10(par->minScale);
+  ip = 0;
+  for (i=0;i<par->nRegions;i++) {
+      for (k=0;k<rgn[i].nPoints;k++){
+          temp=gsl_rng_uniform(ran);
+          flag=0;
+          /*If we're in spherical coordinate system */
+          if (rgn[i].crdType==0){
+              if (rgn[i].sampling==0) {
+                  xmin = log10(rgn[i].xmin);
+                  xmax = log10(rgn[i].xmax);
+                  ymin = cos(rgn[i].ymin);
+                  ymax = cos(rgn[i].ymax);
+                  /* Pick a point and check if we like it or not */
+                  do {
+                      r         = pow(10,xmin+gsl_rng_uniform(ran)*(xmax-xmin));
+                      phi       = rgn[i].zmin + gsl_rng_uniform(ran)*(rgn[i].zmax-rgn[i].zmin);
+                      cos_theta = ymin + gsl_rng_uniform(ran)*(ymax-ymin);
+                      sin_theta = sqrt(1.0 - cos_theta*cos_theta);
+                      x         = r*sin_theta * cos(phi);
+                      y         = r*sin_theta * sin(phi);
+                      if (DIM==3) z         = r*cos_theta;
+                      else z = 0.;
+                      flag = pointEvaluation(par,temp,x,y,z,rgn[i].xref,rgn[i].yref,rgn[i].zref,ip);
+                  } while (!flag);
+                  /* Now pointEvaluation has decided that we like the point */
+                  /* Assign values to the k'th grid point */
+                  /* I don't think we actually need to do this here... */
 
-  /* Sample pIntensity number of points */
-  for(k=0;k<par->pIntensity;k++){
-    temp=gsl_rng_uniform(ran);
-    flag=0;
-    /* Pick a point and check if we like it or not */
-    do{
-      if(par->sampling==0){
-        r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));
-        theta=2.*PI*gsl_rng_uniform(ran);
-        phi=PI*gsl_rng_uniform(ran);
-        sinPhi=sin(phi);
-        x=r*cos(theta)*sinPhi;
-        y=r*sin(theta)*sinPhi;
-        if(DIM==3) z=r*cos(phi);
-        else z=0.;
-      } else if(par->sampling==1){
-        x=(2*gsl_rng_uniform(ran)-1)*par->radius;
-        y=(2*gsl_rng_uniform(ran)-1)*par->radius;
-        if(DIM==3) z=(2*gsl_rng_uniform(ran)-1)*par->radius;
-        else z=0;
-      } else if(par->sampling==2){
-        r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));
-        theta=2.*PI*gsl_rng_uniform(ran);
-        if(DIM==3) {
-          z=2*gsl_rng_uniform(ran)-1.;
-          semiradius=r*sqrt(1.-z*z);
-          z*=r;
-        } else {
-          z=0.;
-          semiradius=r;
-        }
-        x=semiradius*cos(theta);
-        y=semiradius*sin(theta);
-      } else {
-        if(!silent) bail_out("Don't know how to sample model");
-        exit(1);
+                  g[ip].id   = ip;
+                  g[ip].x[0] = x;
+                  g[ip].x[1] = y;
+                  g[ip].x[2] = z;
+                  g[ip].sink = 0;
+                  /* This next step needs to be done, even though it looks stupid */
+                  g[ip].dir  = malloc(sizeof(point)*1);
+                  g[ip].ds   = malloc(sizeof(point)*1);
+                  g[ip].neigh = malloc(sizeof(int)*1);
+                  if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
+
+              } else if (rgn[i].sampling==1) {
+                  xmin = rgn[i].xmin;
+                  xmax = rgn[i].xmax;
+                  ymin = cos(rgn[i].ymin);
+                  ymax = cos(rgn[i].ymax);
+                  /* Pick a point and check if we like it or not */
+                  do {
+
+                      r         = xmin+gsl_rng_uniform(ran)*(xmax-xmin);
+                      phi       = rgn[i].zmin + gsl_rng_uniform(ran)*(rgn[i].zmax-rgn[i].zmin);
+                      cos_theta = ymin + gsl_rng_uniform(ran)*(ymax-ymin);
+                      sin_theta = sqrt(1.0 - cos_theta*cos_theta);
+                      x         = r*sin_theta * cos(phi);
+                      y         = r*sin_theta * sin(phi);
+                      if (DIM==3) z         = r*cos_theta;
+                      else z = 0.;
+                      flag = pointEvaluation(par,temp,x,y,z,rgn[i].xref,rgn[i].yref,rgn[i].zref,ip);
+                  } while (!flag);
+                  /* Now pointEvaluation has decided that we like the point */
+                  /* Assign values to the k'th grid point */
+                  /* I don't think we actually need to do this here... */
+
+                  g[ip].id   = ip;
+                  g[ip].x[0] = x;
+                  g[ip].x[1] = y;
+                  g[ip].x[2] = z;
+                  g[ip].sink = 0;
+                  /* This next step needs to be done, even though it looks stupid */
+                  g[ip].dir  = malloc(sizeof(point)*1);
+                  g[ip].ds   = malloc(sizeof(point)*1);
+                  g[ip].neigh = malloc(sizeof(int)*1);
+                  if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
+              } else {
+                  if(!silent) bail_out("Don't know how to sample model");
+                  exit(1);
+              }
+          } else if (rgn[i].crdType==1){
+          /*Cartesian coordinate system*/
+              if (rgn[i].sampling==1){
+                  xmin = rgn[i].xmin;
+                  xmax = rgn[i].xmax;
+                  ymin = cos(rgn[i].ymin);
+                  ymax = cos(rgn[i].ymax);
+                  /* Pick a point and check if we like it or not */
+                  do {
+                      x = xmin + gsl_rng_uniform(ran)*(xmax-xmin);
+                      y = ymin + gsl_rng_uniform(ran)*(ymax-ymin);
+                      z = zmin + gsl_rng_uniform(ran)*(zmax-zmin);
+                      flag = pointEvaluation(par,temp,x,y,z,rgn[i].xref,rgn[i].yref,rgn[i].zref,ip);
+                  } while(!flag);
+                  /* Now pointEvaluation has decided that we like the point */
+                  /* Assign values to the k'th grid point */
+                  /* I don't think we actually need to do this here... */
+
+                  g[ip].id   = ip;
+                  g[ip].x[0] = x;
+                  g[ip].x[1] = y;
+                  g[ip].x[2] = z;
+                  g[ip].sink = 0;
+
+                  /* This next step needs to be done, even though it looks stupid */
+                  g[ip].dir  = malloc(sizeof(point)*1);
+                  g[ip].ds   = malloc(sizeof(point)*1);
+                  g[ip].neigh = malloc(sizeof(int)*1);
+                  if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
+              } else {
+                  if (!silent) bail_out("If the region boundares are set in cartesian coordinates only sampling=1 is allowed");
+                  exit(1);
+              }
+
+          } else {
+              if (!silent) bail_out("Unkown coordinate system type in regions");
+              exit(1);
+          }
+          ip += 1;
       }
-      if((x*x+y*y+z*z)<par->radiusSqu) flag=pointEvaluation(par,temp,x,y,z);
-    } while(!flag);
-    /* Now pointEvaluation has decided that we like the point */
-
-    /* Assign values to the k'th grid point */
-    /* I don't think we actually need to do this here... */
-    g[k].id=k;
-    g[k].x[0]=x;
-    g[k].x[1]=y;
-    if(DIM==3) g[k].x[2]=z;
-    else g[k].x[2]=0.;
-
-    g[k].sink=0;
-    /* This next step needs to be done, even though it looks stupid */
-    g[k].dir=malloc(sizeof(point)*1);
-    g[k].ds =malloc(sizeof(double)*1);
-    g[k].neigh =malloc(sizeof(struct grid *)*1);
-    if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
   }
+
+  k = ip;
+
+
+
+
+  /*lograd=log10(par->radius);*/
+  /*logmin=log10(par->minScale);*/
+
+  /*[> Sample pIntensity number of points <]*/
+  /*for(k=0;k<par->pIntensity;k++){*/
+    /*temp=gsl_rng_uniform(ran);*/
+    /*flag=0;*/
+    /*[> Pick a point and check if we like it or not <]*/
+    /*do{*/
+      /*if(par->sampling==0){*/
+        /*r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));*/
+        /*theta=2.*PI*gsl_rng_uniform(ran);*/
+        /*phi=PI*gsl_rng_uniform(ran);*/
+        /*sinPhi=sin(phi);*/
+        /*x=r*cos(theta)*sinPhi;*/
+        /*y=r*sin(theta)*sinPhi;*/
+        /*if(DIM==3) z=r*cos(phi);*/
+        /*else z=0.;*/
+      /*} else if(par->sampling==1){*/
+        /*x=(2*gsl_rng_uniform(ran)-1)*par->radius;*/
+        /*y=(2*gsl_rng_uniform(ran)-1)*par->radius;*/
+        /*if(DIM==3) z=(2*gsl_rng_uniform(ran)-1)*par->radius;*/
+        /*else z=0;*/
+      /*} else if(par->sampling==2){*/
+        /*r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));*/
+        /*theta=2.*PI*gsl_rng_uniform(ran);*/
+        /*if(DIM==3) {*/
+          /*z=2*gsl_rng_uniform(ran)-1.;*/
+          /*semiradius=r*sqrt(1.-z*z);*/
+          /*z*=r;*/
+        /*} else {*/
+          /*z=0.;*/
+          /*semiradius=r;*/
+        /*}*/
+        /*x=semiradius*cos(theta);*/
+        /*y=semiradius*sin(theta);*/
+      /*} else {*/
+        /*if(!silent) bail_out("Don't know how to sample model");*/
+        /*exit(1);*/
+      /*}*/
+      /*if((x*x+y*y+z*z)<par->radiusSqu) flag=pointEvaluation(par,temp,x,y,z);*/
+    /*} while(!flag);*/
+    /*[> Now pointEvaluation has decided that we like the point <]*/
+
+    /*[> Assign values to the k'th grid point <]*/
+    /*[> I don't think we actually need to do this here... <]*/
+    /*g[k].id=k;*/
+    /*g[k].x[0]=x;*/
+    /*g[k].x[1]=y;*/
+    /*if(DIM==3) g[k].x[2]=z;*/
+    /*else g[k].x[2]=0.;*/
+
+    /*g[k].sink=0;*/
+    /*[> This next step needs to be done, even though it looks stupid <]*/
+    /*g[k].dir=malloc(sizeof(point)*1);*/
+    /*g[k].ds =malloc(sizeof(double)*1);*/
+    /*g[k].neigh =malloc(sizeof(struct grid *)*1);*/
+    /*if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);*/
+  /*}*/
+
+
   /* end model grid point assignment */
   if(!silent) done(4);
 

--- a/src/lime.h
+++ b/src/lime.h
@@ -76,6 +76,7 @@
 #define N_RAN_PER_SEGMENT       3
 #define FAST_EXP_MAX_TAYLOR	3
 #define FAST_EXP_NUM_BITS	8
+#define MAX_REGIONS     30
 
 
 /* input parameters */
@@ -89,6 +90,7 @@ typedef struct {
   char *dust;
   int sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads;
   char **moldatfile;
+  int nRegions;
 } inputPars;
 
 /* Molecular data: shared attributes */
@@ -149,6 +151,23 @@ typedef struct {
   double stokes[3];
 } spec;
 
+/* Spatial regions */
+typedef struct {
+    int crdType;
+    int sampling;
+    double xmin;
+    double xmax;
+    double ymin;
+    double ymax;
+    double zmin;
+    double zmax;
+    double xref;
+    double yref;
+    double zref;
+    int nPoints;
+} region;
+
+
 /* Image information */
 typedef struct {
   int doline;
@@ -187,14 +206,14 @@ void gasIIdust(double,double,double,double *);
 /* More functions */
 
 void   	binpopsout(inputPars *, struct grid *, molData *);
-void   	buildGrid(inputPars *, struct grid *);
+void   	buildGrid(inputPars *, struct grid *, region *);
 void    calcSourceFn(double dTau, const inputPars *par, double *remnantSnu, double *expDTau);
 void	continuumSetup(int, image *, molData *, inputPars *, struct grid *);
 void	distCalc(inputPars *, struct grid *);
 void	fit_d1fi(double, double, double*);
 void    fit_fi(double, double, double*);
 void    fit_rr(double, double, double*);
-void   	input(inputPars *, image *);
+void   	input(inputPars *, image *, region *);
 float  	invSqrt(float);
 void    freeInput(inputPars *, image*, molData* m );
 void   	freeGrid(const inputPars * par, const molData* m, struct grid * g);
@@ -218,9 +237,9 @@ void   	molinit(molData *, inputPars *, struct grid *,int);
 void    openSocket(inputPars *par, int);
 void	qhull(inputPars *, struct grid *);
 void  	photon(int, struct grid *, molData *, int, const gsl_rng *,inputPars *,blend *,gridPointData *,double *);
-void	parseInput(inputPars *, image **, molData **);
+void	parseInput(inputPars *, image **, molData **, region **);
 double 	planckfunc(int, double, molData *, int);
-int     pointEvaluation(inputPars *,double, double, double, double);
+int     pointEvaluation(inputPars *,double, double, double, double, double, double, double, int);
 void   	popsin(inputPars *, struct grid **, molData **, int *);
 void   	popsout(inputPars *, struct grid *, molData *);
 void	predefinedGrid(inputPars *, struct grid *);

--- a/src/lime.h
+++ b/src/lime.h
@@ -215,7 +215,7 @@ void    fit_fi(double, double, double*);
 void    fit_rr(double, double, double*);
 void   	input(inputPars *, image *, region *);
 float  	invSqrt(float);
-void    freeInput(inputPars *, image*, molData* m );
+void    freeInput(inputPars *, image*, molData* m, region*);
 void   	freeGrid(const inputPars * par, const molData* m, struct grid * g);
 void   	freePopulation(const inputPars * par, const molData* m, struct populations * pop);
 double 	gaussline(double, double);

--- a/src/main.c
+++ b/src/main.c
@@ -69,6 +69,6 @@ int main () {
   if(!silent) goodnight(initime,img[0].filename);
 
   freeGrid( &par, m, g);
-  freeInput(&par, img, m);
+  freeInput(&par, img, m, rgn);
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@ int main () {
   inputPars    par;
   struct grid* g = NULL;
   image*       img = NULL;
+  region*      rgn = NULL;
 
   if(!silent) greetings();
   if(!silent) screenInfo();
@@ -36,7 +37,7 @@ int main () {
   calcTableEntries(FAST_EXP_MAX_TAYLOR, FAST_EXP_NUM_BITS);
 #endif
 
-  parseInput(&par,&img,&m);
+  parseInput(&par,&img,&m,&rgn);
 
   if(par.doPregrid)
     {
@@ -50,7 +51,7 @@ int main () {
   else
     {
       gridAlloc(&par,&g);
-      buildGrid(&par,g);
+      buildGrid(&par,g,rgn);
     }
 
   for(i=0;i<par.nImages;i++){

--- a/src/smooth.c
+++ b/src/smooth.c
@@ -17,7 +17,7 @@ smooth(inputPars *par, struct grid *g){
   int k=0,j,i;		/* counters									*/
   int sg;		/* counter for smoothing the grid			*/
   int cn;
-  int smooth=20;	/* Amount of grid smoothing					*/
+  int smooth=5;	/* Amount of grid smoothing					*/
   double move[3];	/* Auxillary array for smoothing the grid	*/
   double dist;		/* Distance to a neighbor					*/
   	


### PR DESCRIPTION
Dear Lime developers, 

My name is Attila Juhasz, currently I am a postdoc in the Institute of Astronomy in Cambridge. Previously I was a member of the dutch ARC node (Allegro) at the Leiden Observatory. While I was working for Allegro I have a made a few changes to Lime and I thought they might be useful for the community. I made a  few small changes to the VTK output (removing velocity normalisation and changing cell type), but the most significant change is in the grid building. I reduced the number of smoothing iterations in the Lloyd's algorithm from 20 to 5. This algorithm is regularising the grid which is not necessarily a good thing in all situations. Too much smoothing can seriously decrease the effect of weighted sampling in the grid point selection. I also moved the pointEvaluation() function from weights.c to the model.c as the weighting function might be edited by the users frequently. The final change to the grid building is that I introduced spatial regions. The point evaluation process during grid building runs for each spatial region separately. Each region (defined by 3D cartesian or spherical coordinate boundaries) has a certain number of grid points, a reference radius and a sampling type (i.e. logarithmic or linear). The weighting function can be also different for each region. Using such regions it is easy to add extra points to the grid to a very specific spatial location. This can be important if the molecular layer represents only a small fraction of the total model volume. The 'sampling' and 'pIntensity' in the parameter structure are omitted if regions are used. The sampling is now defined for each region separately, while the value of pIntensity is calculated as the total number of points in all regions together. 

Cheers
Attila 