### PR TITLE
Save memory for sink points

### DIFF
--- a/src/molinit.c
+++ b/src/molinit.c
@@ -256,7 +256,7 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
       }
     }
 
-    for(id=0;id<par->ncell;id++){
+    for(id=0;id<par->par->pIntensity;id++){
       g[id].mol[i].partner=malloc(sizeof(struct rates)*m[i].npart);
       for(ipart=0;ipart<m[i].npart;ipart++){
         g[id].mol[i].partner[ipart].up = malloc(sizeof(double)*m[i].ntrans[ipart]);
@@ -264,7 +264,7 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
       }
     }
 
-    for(id=0;id<par->ncell;id++){
+    for(id=0;id<par->pIntensity;id++){
       for(ipart=0;ipart<m[i].npart;ipart++){
         for(itrans=0;itrans<m[i].ntrans[ipart];itrans++){
           if((g[id].t[0]>part[ipart].temp[0])&&(g[id].t[0]<part[ipart].temp[ntemp[ipart]-1])){
@@ -297,10 +297,12 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
 
   /* Allocate space for populations and opacities */
   for(id=0;id<par->ncell; id++){
-    g[id].mol[i].pops = malloc(sizeof(double)*m[i].nlev);
+    if(!g[id].sink){
+      g[id].mol[i].pops = malloc(sizeof(double)*m[i].nlev);
+      for(ilev=0;ilev<m[i].nlev;ilev++) g[id].mol[i].pops[ilev]=0.0;
+    }
     g[id].mol[i].dust = malloc(sizeof(double)*m[i].nline);
     g[id].mol[i].knu  = malloc(sizeof(double)*m[i].nline);
-    for(ilev=0;ilev<m[i].nlev;ilev++) g[id].mol[i].pops[ilev]=0.0;
   }
 
   /* Get dust opacities */

--- a/src/molinit.c
+++ b/src/molinit.c
@@ -256,7 +256,7 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
       }
     }
 
-    for(id=0;id<par->par->pIntensity;id++){
+    for(id=0;id<par->pIntensity;id++){
       g[id].mol[i].partner=malloc(sizeof(struct rates)*m[i].npart);
       for(ipart=0;ipart<m[i].npart;ipart++){
         g[id].mol[i].partner[ipart].up = malloc(sizeof(double)*m[i].ntrans[ipart]);

--- a/src/popsin.c
+++ b/src/popsin.c
@@ -88,8 +88,10 @@ popsin(inputPars *par, struct grid **g, molData **m, int *popsdone){
     fread(&(*g)[i].dopb, sizeof (*g)[i].dopb, 1, fp);
     (*g)[i].mol=malloc(par->nSpecies*sizeof(struct populations));
     for(j=0;j<par->nSpecies;j++){
-      (*g)[i].mol[j].pops=malloc(sizeof(double)*(*m)[j].nlev);
-      for(k=0;k<(*m)[j].nlev;k++) fread(&(*g)[i].mol[j].pops[k], sizeof(double), 1, fp);
+      if(!(*g)[i].sink){
+        (*g)[i].mol[j].pops=malloc(sizeof(double)*(*m)[j].nlev);
+        for(k=0;k<(*m)[j].nlev;k++) fread(&(*g)[i].mol[j].pops[k], sizeof(double), 1, fp);
+      }
       (*g)[i].mol[j].knu=malloc(sizeof(double)*(*m)[j].nline);
       for(k=0;k<(*m)[j].nline;k++) fread(&(*g)[i].mol[j].knu[k], sizeof(double), 1, fp);
       (*g)[i].mol[j].dust=malloc(sizeof(double)*(*m)[j].nline);

--- a/src/popsout.c
+++ b/src/popsout.c
@@ -72,7 +72,7 @@ binpopsout(inputPars *par, struct grid *g, molData *m){
     fwrite(g[i].nmol,  sizeof(double)*par->nSpecies,1, fp);
     fwrite(&g[i].dopb, sizeof g[i].dopb, 1, fp);
     for(j=0;j<par->nSpecies;j++){
-      fwrite(g[i].mol[j].pops,  sizeof(double)*m[j].nlev, 1, fp);
+      if(!g[i].sink) fwrite(g[i].mol[j].pops,  sizeof(double)*m[j].nlev, 1, fp);
       fwrite(g[i].mol[j].knu,   sizeof(double)*m[j].nline,1, fp);
       fwrite(g[i].mol[j].dust,  sizeof(double)*m[j].nline,1, fp);
       fwrite(&g[i].mol[j].dopb, sizeof(double),           1, fp);

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -294,6 +294,7 @@ kept it.
   int ichan,i,px,iline,tmptrans,count;
   double size,xp,yp,minfreq,absDeltaFreq;
   double cutoff;
+  int qhullShortMem1, qhullShortMem2;
 
   gsl_rng *ran = gsl_rng_alloc(gsl_rng_ranlxs2);	/* Random number generator */
 #ifdef TEST
@@ -517,6 +518,9 @@ This part works great! This is "Shepard's method" with a weight of 8. Slow, unfo
   free(rays);
   free(counta);
   free(countb);
+  qh_freeqhull(qh_ALL);
+  qh_memfreeshort(&qhullShortMem1, &qhullShortMem2);  /* free short memory */
+  if(!silent && (qhullShortMem1 || qhullShortMem2)) warning("Qhull failed to free all short memory");
 }
 
 

--- a/src/sourcefunc.c
+++ b/src/sourcefunc.c
@@ -18,7 +18,7 @@ sourceFunc(double *snu, double *dtau, double ds, molData *m,double vfac,struct g
   jnu	 = g[pos].mol[ispec].dust[iline]*g[pos].mol[ispec].knu[iline];
   
   /* Line part:		j_nu = v*consts*1/b*rho*n_i*A_ij */
-  if(doline) jnu	+= vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*g[pos].mol[ispec].pops[m[ispec].lau[iline]]*m[ispec].aeinst[iline];
+  if(doline && !g[pos].sink) jnu	+= vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*g[pos].mol[ispec].pops[m[ispec].lau[iline]]*m[ispec].aeinst[iline];
   
   
   
@@ -28,7 +28,7 @@ sourceFunc(double *snu, double *dtau, double ds, molData *m,double vfac,struct g
   
   
   /* Line part: alpha_nu = v*const*1/b*rho*(n_j*B_ij-n_i*B_ji) */
-  if(doline) alpha += vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*(g[pos].mol[ispec].pops[m[ispec].lal[iline]]*m[ispec].beinstl[iline]
+  if(doline && !g[pos].sink) alpha += vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*(g[pos].mol[ispec].pops[m[ispec].lal[iline]]*m[ispec].beinstl[iline]
                                                                           -g[pos].mol[ispec].pops[m[ispec].lau[iline]]*m[ispec].beinstu[iline]);
   
   
@@ -46,13 +46,14 @@ sourceFunc(double *snu, double *dtau, double ds, molData *m,double vfac,struct g
 void
 sourceFunc_line(double *jnu, double *alpha, molData *m,double vfac,struct grid *g,int pos,int ispec, int iline){
   
-  /* Line part:		j_nu = v*consts*1/b*rho*n_i*A_ij */
-  *jnu   += vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*g[pos].mol[ispec].pops[m[ispec].lau[iline]]*m[ispec].aeinst[iline];
+  if(!g[pos].sink) {
+    /* Line part:		j_nu = v*consts*1/b*rho*n_i*A_ij */
+    *jnu   += vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*g[pos].mol[ispec].pops[m[ispec].lau[iline]]*m[ispec].aeinst[iline];
   
-  /* Line part: alpha_nu = v*const*1/b*rho*(n_j*B_ij-n_i*B_ji) */
-  *alpha += vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*(g[pos].mol[ispec].pops[m[ispec].lal[iline]]*m[ispec].beinstl[iline]
-                                                                -g[pos].mol[ispec].pops[m[ispec].lau[iline]]*m[ispec].beinstu[iline]);
-  
+    /* Line part: alpha_nu = v*const*1/b*rho*(n_j*B_ij-n_i*B_ji) */
+    *alpha += vfac*HPIP*g[pos].mol[ispec].binv*g[pos].nmol[ispec]*(g[pos].mol[ispec].pops[m[ispec].lal[iline]]*m[ispec].beinstl[iline]
+                                                                  -g[pos].mol[ispec].pops[m[ispec].lau[iline]]*m[ispec].beinstu[iline]);
+  }
   return;
 }
 


### PR DESCRIPTION
Dear LIME team,

I've made relatively big number of changes in the LIME code version 1.4b. Most of these changes are for the better performance. I even made an Open MPI version of the code which works well and allows for heavy computations on HPC clusters. I'd like to contribute these changes (most of the them).

The commits which I'm sending now allow to safe memory. The code do not perform computations of level populations in the sink points. In the case of high number of molecular levels and grid points the allocated memory for the populations and collisional rates in the sink points is not used but can significantly consume RAM. I've made so that this unused memory is not allocated. According with this change I also changed the procedures of reading and writing of binary model files. At the moment changes in these two procedures are breaking because they do not allow to use binary files obtained with the current version of the LIME code. The compatibility can be saved by using dummy variables during reading/writing binary files but I've decided to not use such possibility because dummy variables will consume the space on a hard disk.

I'm really new with github and git. Please tell me if I made something wrong in the sense of technical things like commiting, pushing etc.

Regards

Sergey.