### PR TITLE
Lapack/MKL support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ MODELO 	= src/model.o
 
 #CCFLAGS = -O3 -falign-loops=16 -fno-strict-aliasing -DTEST -DFASTEXP -DNO_NCURSES
 CCFLAGS = -O3 -falign-loops=16 -fno-strict-aliasing
-LDFLAGS = -lgsl -lgslcblas -l${QHULL} -lcfitsio -lncurses -lm 
+LDFLAGS = -lgsl -lgslcblas -l${QHULL} -lcfitsio -lncurses -lm ${EXTRALDFLAGS}
 
 .SILENT:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,22 @@ LIME needs to be able to find both shared-object libraries (files which usually 
 
 If you have the older version of either qhull or cfitsio, set the respective environment variables OLD_QHULL and/or OLD_FITSIO to T.
 
+### Support of LAPACK or Intel MKL linear equation solvers
 
+The code optionally support using of LAPACK or MKL (Math Kernel Library) linear equation solver instead of one provided by gsl. To use LAPACK solver in Mac OS X one needs to install BLAS and LAPACK packages. These packages can be installed by typing in a terminal
+
+```
+$ port install blas
+$ port install lapack
+```
+
+Alternatively these packages can be compiled from the source code that can be downloaded from the following links. Make sure to get the latest version of LAPACK which inludes LAPACKE C interface to LAPACK.
+
+- [blas](http://www.netlib.org/blas/)
+- [lapack](http://www.netlib.org/lapack/)
+
+The LAPACK package is present on most modern Unix and Linux systems.
+Intel Math Kernel Library (MKL) can be installed following its installation guide.
 
 Running the code
 ----------------

--- a/lime
+++ b/lime
@@ -23,6 +23,8 @@ function usage {
     echo "   -f           Use fast exponential computation"
     echo "   -n           Turn off ncurses output"
     echo "   -p NTHREADS  Run in parallel with NTHREADS threads (default: 1)"
+    echo "   -M           Use Intel MKL solver"
+    echo "   -L           Use LAPACK solver"
     echo ""
     echo "See <http://lime.readthedocs.org> for more information."
     echo "Report bugs to <http://github.com/lime-rt/lime/issues>."
@@ -32,8 +34,9 @@ function tip {
     echo "Try 'lime -h' for more information."
 }
 
-options=":Vfnp:h"
+options=":Vfnp:hML"
 cpp_flags=""
+ld_flags=""
 
 while getopts ${options} opt; do
     case $opt in
@@ -61,6 +64,14 @@ while getopts ${options} opt; do
 		exit 1
 	    fi
 	    ;;
+	M)
+	    cpp_flags+="-DUSE_MKL "
+	    ld_flags+="-lmkl_lapack95_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5 -lpthread "
+	    ;;
+	L)
+	    cpp_flags+="-DUSE_LAPACK "
+	    ld_flags+="-llapack -llapacke "
+	    ;;
 	\?)
 	    echo "lime: error: unknown option" >&2
 	    tip
@@ -84,7 +95,7 @@ export WORKDIR=$PWD
 
 # Compile the code
 pushd ${PATHTOLIME} >> /dev/null
-make EXTRACPPFLAGS="${cpp_flags}" MODELS=$WORKDIR/$1 TARGET=$WORKDIR/lime_$$.x
+make EXTRACPPFLAGS="${cpp_flags}" EXTRALDFLAGS="${ld_flags}" MODELS=$WORKDIR/$1 TARGET=$WORKDIR/lime_$$.x
 make clean
 
 # Run the code


### PR DESCRIPTION
These commits provide possibility to use LAPACK or Intel MKL linear equation solvers in the stateq procedure. Using of these solvers for the model provided in the example directory of the lime distribution do not lead to any significant changes in the results or time of the code execution (comparing with GSL solver). But if the file hco+@xpol.dat will be replaced on, for example, a-ch3oh.dat file from LAMDA database then there can be a problems with GSL solver. GSL solver can be very slow in that case or it can even fall with an error. LAPACK or MKL solvers allow to avoid such problems and allow to perform fast computations even when GLS fails (which often happens in the case of high number of molecular levels).