### PR TITLE
Modification of predefgrid

### DIFF
--- a/doc/usermanual.rst
+++ b/doc/usermanual.rst
@@ -409,6 +409,11 @@ If this option is used, LIME will not generate its own grid, but rather
 use the grid defined in this file. The file needs to contain all
 physical properties of the grid points, i.e., density, temperature,
 abundance, velocity etc. There is no default value.
+An experienced user can change what physical properties will be taken 
+from the input file. This can be done modifying the predefinedGrid 
+function in the predefgrid.c file. The physical properties that will not 
+be taken from the input file will be computed with the model 
+functions (see below).
 
 .. code:: c
 

--- a/src/aux.c
+++ b/src/aux.c
@@ -39,6 +39,7 @@ parseInput(inputPars *par, image **img, molData **m){
   par->sinkPoints=0;
   par->doPregrid=0;
   par->nThreads=0;
+  par->pregridVel=0;
 
   /* Allocate space for output fits images */
   (*img)=malloc(sizeof(image)*MAX_NSPECIES);

--- a/src/lime.h
+++ b/src/lime.h
@@ -87,7 +87,7 @@ typedef struct {
   char *pregrid;
   char *restart;
   char *dust;
-  int sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads;
+  int sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads,pregridVel;
   char **moldatfile;
 } inputPars;
 

--- a/src/photon.c
+++ b/src/photon.c
@@ -217,7 +217,7 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
         ds=g[here].ds[dir]/2.;
         halfFirstDs[iphot]=ds;
         for(l=0;l<par->nSpecies;l++){
-          if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
+          if(!par->doPregrid  || !par->pregridVel) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
           else velocityspline_lin(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
           mp[l].vfac[iphot]=vfac[0];
         }
@@ -228,7 +228,7 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
       }
       
       for(l=0;l<par->nSpecies;l++){
-        if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
+        if(!par->doPregrid || !par->pregridVel) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
         else velocityspline_lin(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
       }
       
@@ -259,7 +259,7 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
           alpha=0.;
           for(jline=0;jline<sizeof(matrix)/sizeof(blend);jline++){
             if(matrix[jline].line1 == jline || matrix[jline].line2 == jline){	
-              if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[counta[jline]].binv,deltav-matrix[jline].deltav,&vblend);
+              if(!par->doPregrid || !par->pregridVel) velocityspline(g,here,dir,g[id].mol[counta[jline]].binv,deltav-matrix[jline].deltav,&vblend);
               else velocityspline_lin(g,here,dir,g[id].mol[counta[jline]].binv,deltav-matrix[jline].deltav,&vblend);	
               sourceFunc_line(&jnu,&alpha,m,vblend,g,here,counta[jline],countb[jline]);
               dtau=alpha*ds;

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -125,7 +125,7 @@ traceray(rayData ray, int tmptrans, int im, inputPars *par, struct grid *g, molD
               vThisChan=(ichan-(img[im].nchan-1)/2.)*img[im].velres; // Consistent with the WCS definition in writefits().
               deltav = vThisChan - img[im].source_vel + shift;
 
-              if(!par->pregrid) velocityspline2(x,dx,ds,g[posn].mol[counta[iline]].binv,deltav,&vfac);
+              if(!par->pregrid || !par->pregridVel) velocityspline2(x,dx,ds,g[posn].mol[counta[iline]].binv,deltav,&vfac);
               else vfac=gaussline(deltav+veloproject(dx,g[posn].vel),g[posn].mol[counta[iline]].binv);
 
               sourceFunc_line(&jnu,&alpha,m,vfac,g,posn,counta[iline],countb[iline]);


### PR DESCRIPTION
The code (photon and traceray procedures) assumes that if the user supplies predefined grid then the velocity field is taken from this grid. The user may want to change the format of file with the predefined grid so that the velocity will not be taken from this file.

These commits allow the code to check whether the user supplies the velocity field with the predefined grid and to use appropriate functions in photon and traceray procedures. With these commits the code also will check whether other physical properties were taken from the input file with predefined grid. It may be useful if the user wants to change the format of the input file.