### PR TITLE
Initial lte solution

### DIFF
--- a/doc/usermanual.rst
+++ b/doc/usermanual.rst
@@ -419,6 +419,13 @@ default lte\_only=0, i.e., full non-LTE calculation.
 
 .. code:: c
 
+    (integer) par->init_lte (optional)
+
+If set, LIME use LTE approximation as initial one for subsequent non-LTE calculations. The
+default init\_lte=0, i.e., the code will use constant value for level populations as initial solution.
+
+.. code:: c
+
     (integer) par->blend (optional)
 
 If set, LIME takes line blending into account, however, only if there

--- a/src/LTEsolution.c
+++ b/src/LTEsolution.c
@@ -26,6 +26,5 @@ LTE(inputPars *par, struct grid *g, molData *m){
       }
     }
   }
-  if(par->outputfile) popsout(par,g,m);
 }
 

--- a/src/aux.c
+++ b/src/aux.c
@@ -31,6 +31,7 @@ parseInput(inputPars *par, image **img, molData **m){
 
   par->tcmb = 2.728;
   par->lte_only=0;
+  par->init_lte=0;
   par->sampling=2;
   par->blend=0;
   par->antialias=1;
@@ -469,7 +470,7 @@ levelPops(molData *m, inputPars *par, struct grid *g, int *popsdone){
   /* Check for blended lines */
   lineBlend(m,par,&matrix);
 
-  if(par->lte_only) LTE(par,g,m);
+  if(par->lte_only || par->init_lte) LTE(par,g,m);
 
   for(id=0;id<par->pIntensity;id++){
     stat[id].pop=malloc(sizeof(double)*m[0].nlev*5);

--- a/src/lime.h
+++ b/src/lime.h
@@ -87,7 +87,7 @@ typedef struct {
   char *pregrid;
   char *restart;
   char *dust;
-  int sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads;
+  int sampling,collPart,lte_only,init_lte,antialias,polarization,doPregrid,nThreads;
   char **moldatfile;
 } inputPars;
 


### PR DESCRIPTION
These commits allow the user to set whether to use LTE as initial approximation for subsequent non-LTE calculations. This may be useful for models with high gas densities.