### PR TITLE
Changed values of some constants defined in lime.h 

### DIFF
--- a/src/fastexp.c
+++ b/src/fastexp.c
@@ -12,6 +12,7 @@
 
 extern double EXP_TABLE_2D[128][10];
 extern double EXP_TABLE_3D[256][2][10];
+extern double INV_TABLE[FAST_EXP_MAX_TAYLOR];
 
 
 int factorial(const int n){
@@ -181,9 +182,10 @@ See description of the lookup algorithm in function calcFastExpRange().
       }
     }
   }
+  for (l=0;l<FAST_EXP_MAX_TAYLOR;l++) INV_TABLE[l]=1.0/(l+1.0);
 }
 
-inline double FastExp(const float negarg){
+double FastExp(const float negarg){
   /*
 See description of the lookup algorithm in function calcFastExpRange(). ****NOTE!**** Most numbers here are hard-wired for the sake of speed. If need be, they can be verified (or recalculated for different conditions) via calcTableEntries().
   */
@@ -216,7 +218,7 @@ This value should be calculated from 127+lowestExponent, where 127 is the offset
   if (l<0){ // do the Taylor approximation.
     result = 1.0;
     for (i=FAST_EXP_MAX_TAYLOR;i>0;i--){
-      result = 1.0 - negarg*result/(double)i;
+      result = 1.0 - negarg*INV_TABLE[i-1]*result;
     }
     return result;
 
@@ -232,4 +234,3 @@ This value should be calculated from 127+lowestExponent, where 127 is the offset
           EXP_TABLE_3D[j1][0][l]*
           EXP_TABLE_3D[j2][1][l]);
 }
-

--- a/src/lime.h
+++ b/src/lime.h
@@ -77,7 +77,6 @@
 #define FAST_EXP_MAX_TAYLOR	3
 #define FAST_EXP_NUM_BITS	8
 
-
 /* input parameters */
 typedef struct {
   double radius,radiusSqu,minScale,minScaleSqu,tcmb,taylorCutoff;
@@ -246,7 +245,8 @@ int	factorial(const int n);
 double	taylor(const int maxOrder, const float x);
 void	calcFastExpRange(const int maxTaylorOrder, const int maxNumBitsPerMantField, int *numMantissaFields, int *lowestExponent, int *numExponentsUsed);
 void	calcTableEntries(const int maxTaylorOrder, const int maxNumBitsPerMantField);
-inline double	FastExp(const float negarg);
+double FastExp(const float negarg);
+
 
 
 /* Curses functions */

--- a/src/lime.h
+++ b/src/lime.h
@@ -236,7 +236,6 @@ void   	stateq(int, struct grid *, molData *, int, inputPars *,gridPointData *,d
 void	statistics(int, molData *, struct grid *, int *, double *, double *, int *);
 void    stokesangles(double, double, double, double, double *);
 void    traceray(rayData, int, int, inputPars *, struct grid *, molData *, image *, int, int *, int *, double);
-void   	velocityspline(struct grid *, int, int, double, double, double*);
 void   	velocityspline2(double *, double *, double, double, double, double*);
 double 	veloproject(double *, double *);
 void	writefits(int, inputPars *, molData *, image *);

--- a/src/lime.h
+++ b/src/lime.h
@@ -48,26 +48,26 @@
 
 /* Physical constants */
 #define PI			3.14159265358979323846
-#define SPI			1.77245385
-#define CLIGHT	    2.997924562e8
-#define HPLANCK	    6.626196e-34
-#define KBOLTZ	    1.380622e-23
-#define AMU			1.6605402e-27
-#define HPIP		HPLANCK*CLIGHT/4.0/PI/SPI
-#define HCKB		100.*HPLANCK*CLIGHT/KBOLTZ
-#define PC			3.08568025e16
-#define AU			1.49598e11
-#define maxp		0.15
-#define OtoP		3.
-#define GRAV		6.67428e-11
+#define SPI			1.77245385090552
+#define CLIGHT	    		299792458.0
+#define HPLANCK	    		6.626070040e-34
+#define KBOLTZ	    		1.3806488e-23
+#define AMU			1.660538921e-27
+#define HPIP			(HPLANCK*CLIGHT/4.0/PI/SPI)
+#define HCKB			(100.*HPLANCK*CLIGHT/KBOLTZ)
+#define PC			3.085677581e16
+#define AU			149597870700.0
+#define maxp			0.15
+#define OtoP			3.
+#define GRAV			6.67384e-11
 
 /* Other constants */
-#define NITERATIONS 	16
+#define NITERATIONS 		16
 #define max_phot		10000		/* don't set this value higher unless you have enough memory. */
 #define ininphot		9
 #define minpop			1.e-6
-#define eps				1.0e-30
-#define TOL				1e-6
+#define eps			1.0e-30
+#define TOL			1e-6
 #define MAXITER			50
 #define goal			50
 #define fixset			1e-6

--- a/src/main.c
+++ b/src/main.c
@@ -12,12 +12,14 @@
 #ifdef FASTEXP
 double EXP_TABLE_2D[128][10];
 double EXP_TABLE_3D[256][2][10];
+double INV_TABLE[FAST_EXP_MAX_TAYLOR];
 /* I've hard-wired the dimensions of these arrays, but it would be better perhaps to declare them as pointers, and calculate the dimensions with the help of the function call:
   calcFastExpRange(FAST_EXP_MAX_TAYLOR, FAST_EXP_NUM_BITS, &numMantissaFields, &lowestExponent, &numExponentsUsed)
 */
 #else
 double EXP_TABLE_2D[1][1]; // nominal definitions so the fastexp.c module will compile.
 double EXP_TABLE_3D[1][1][1];
+double INV_TABLE[1];
 #endif
 
 int main () {

--- a/src/photon.c
+++ b/src/photon.c
@@ -78,21 +78,22 @@ sortangles(double *inidir, int id, struct grid *g, const gsl_rng *ran) {
 void
 velocityspline(struct grid *g, int id, int k, double binv, double deltav, double *vfac, double *oridir){
   int nspline,ispline,naver,iaver;
-  double v1,v2,s1,s2,sd,v,vfacsub,d;
+  double v1,v2,s1,s2,sd,v,vfacsub,d,proj;
 
-#ifdef OLD_RT
   v1=deltav-veloproject(g[id].dir[k].xn,g[id].vel);
   v2=deltav-veloproject(g[id].dir[k].xn,g[id].neigh[k]->vel);
-#else
-  v1=deltav-veloproject(oridir,g[id].vel);
-  v2=deltav-veloproject(oridir,g[id].neigh[k]->vel);
-#endif
 
   nspline=(fabs(v1-v2)*binv < 1) ? 1 : (int)(fabs(v1-v2)*binv);
   *vfac=0.;
   s2=0;
   v2=v1;
-  
+
+#ifdef OLD_RT
+  proj=1.0;
+#else
+  proj=oridir[0]*g[id].dir[k].xn[0]+oridir[1]*g[id].dir[k].xn[1]+oridir[2]*g[id].dir[k].xn[2];  
+#endif
+
   for(ispline=0;ispline<nspline;ispline++){
     s1=s2;
     s2=((double)(ispline+1))/(double)nspline;
@@ -103,7 +104,7 @@ velocityspline(struct grid *g, int id, int k, double binv, double deltav, double
     for(iaver=0;iaver<naver;iaver++){
       sd=s1+(s2-s1)*((double)iaver-0.5)/(double)naver;
       d=sd*g[id].ds[k];
-      v=deltav-((((g[id].a4[k]*d+g[id].a3[k])*d+g[id].a2[k])*d+g[id].a1[k])*d+g[id].a0[k]);
+      v=deltav-proj*((((g[id].a4[k]*d+g[id].a3[k])*d+g[id].a2[k])*d+g[id].a1[k])*d+g[id].a0[k]);
       vfacsub=gaussline(v,binv);
       *vfac+=vfacsub/(double)naver;
     }
@@ -116,21 +117,22 @@ velocityspline(struct grid *g, int id, int k, double binv, double deltav, double
 void
 velocityspline_lin(struct grid *g, int id, int k, double binv, double deltav, double *vfac, double *oridir){
   int nspline,ispline,naver,iaver;
-  double v1,v2,s1,s2,sd,v,vfacsub,d;
+  double v1,v2,s1,s2,sd,v,vfacsub,d,proj;
   
-#ifdef OLD_RT
   v1=deltav-veloproject(g[id].dir[k].xn,g[id].vel);
   v2=deltav-veloproject(g[id].dir[k].xn,g[id].neigh[k]->vel);
-#else
-  v1=deltav-veloproject(oridir,g[id].vel);
-  v2=deltav-veloproject(oridir,g[id].neigh[k]->vel);
-#endif
 
   nspline=(fabs(v1-v2)*binv < 1) ? 1 : (int)(fabs(v1-v2)*binv);
   *vfac=0.;
   s2=0;
   v2=v1;
   
+#ifdef OLD_RT
+  proj=1.0;
+#else
+  proj=oridir[0]*g[id].dir[k].xn[0]+oridir[1]*g[id].dir[k].xn[1]+oridir[2]*g[id].dir[k].xn[2];  
+#endif
+
   for(ispline=0;ispline<nspline;ispline++){
     s1=s2;
     s2=((double)(ispline+1))/(double)nspline;
@@ -141,7 +143,7 @@ velocityspline_lin(struct grid *g, int id, int k, double binv, double deltav, do
     for(iaver=0;iaver<naver;iaver++){
       sd=s1+(s2-s1)*((double)iaver-0.5)/(double)naver;
       d=sd*g[id].ds[k];
-      v=deltav-(g[id].a1[k]*d+g[id].a0[k]);
+      v=deltav-proj*(g[id].a1[k]*d+g[id].a0[k]);
       vfacsub=gaussline(v,binv);
       *vfac+=vfacsub/(double)naver;
     }

--- a/src/photon.c
+++ b/src/photon.c
@@ -11,9 +11,9 @@
 
 int
 sortangles(double *inidir, int id, struct grid *g, const gsl_rng *ran) {
+#ifdef OLD_RT
   int i,n[2];
   double angle,exitdir[2];
-
   exitdir[0]=1e30;
   exitdir[1]=1e31;
   n[0]=-1;
@@ -45,17 +45,48 @@ sortangles(double *inidir, int id, struct grid *g, const gsl_rng *ran) {
     }
     return n[1];
   }
+#else
+  // the old method finds the edge with the lowest dir\cdot inidir,
+  // i.e. the edge closest to the direction opposite to the inidir
+  // this has been changed, because it makes things cleaner
+  // when, e.g., calculating projections
+
+  int i,n;
+  double cos_angle,exit_cos;
+  exit_cos=-1e30;
+  n=-1;
+
+  for(i=0;i<g[id].numNeigh;i++){
+    cos_angle=( inidir[0]*g[id].dir[i].xn[0]
+           +inidir[1]*g[id].dir[i].xn[1]
+           +inidir[2]*g[id].dir[i].xn[2]);
+    if(cos_angle>exit_cos){
+      exit_cos=cos_angle;
+      n=i;
+    }
+  }
+  if(n==-1){
+    if(!silent) bail_out("Photon propagation error");
+    exit(1);
+  }
+  return n;
+#endif
 }
 
 
 
 void
-velocityspline(struct grid *g, int id, int k, double binv, double deltav, double *vfac){
+velocityspline(struct grid *g, int id, int k, double binv, double deltav, double *vfac, double *oridir){
   int nspline,ispline,naver,iaver;
   double v1,v2,s1,s2,sd,v,vfacsub,d;
-  
+
+#ifdef OLD_RT
   v1=deltav-veloproject(g[id].dir[k].xn,g[id].vel);
   v2=deltav-veloproject(g[id].dir[k].xn,g[id].neigh[k]->vel);
+#else
+  v1=deltav-veloproject(oridir,g[id].vel);
+  v2=deltav-veloproject(oridir,g[id].neigh[k]->vel);
+#endif
 
   nspline=(fabs(v1-v2)*binv < 1) ? 1 : (int)(fabs(v1-v2)*binv);
   *vfac=0.;
@@ -83,12 +114,17 @@ velocityspline(struct grid *g, int id, int k, double binv, double deltav, double
 
 
 void
-velocityspline_lin(struct grid *g, int id, int k, double binv, double deltav, double *vfac){
+velocityspline_lin(struct grid *g, int id, int k, double binv, double deltav, double *vfac, double *oridir){
   int nspline,ispline,naver,iaver;
   double v1,v2,s1,s2,sd,v,vfacsub,d;
   
+#ifdef OLD_RT
   v1=deltav-veloproject(g[id].dir[k].xn,g[id].vel);
   v2=deltav-veloproject(g[id].dir[k].xn,g[id].neigh[k]->vel);
+#else
+  v1=deltav-veloproject(oridir,g[id].vel);
+  v2=deltav-veloproject(oridir,g[id].neigh[k]->vel);
+#endif
 
   nspline=(fabs(v1-v2)*binv < 1) ? 1 : (int)(fabs(v1-v2)*binv);
   *vfac=0.;
@@ -168,7 +204,7 @@ void
 photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPars *par,blend *matrix, gridPointData *mp, double *halfFirstDs){
   int iphot,iline,jline,here,there,firststep,dir,np_per_line,ip_at_line,l;
   int *counta, *countb,nlinetot;
-  double deltav,segment,vblend,dtau,expDTau,jnu,alpha,ds,vfac[par->nSpecies],pt_theta,pt_z,semiradius;
+  double deltav,segment,vblend,dtau,expDTau,jnu,alpha,ds,ds_prev,vfac[par->nSpecies],pt_theta,pt_z,semiradius;
   double *tau,*expTau,vel[3],x[3], inidir[3];
   double remnantSnu;
 
@@ -194,7 +230,7 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
     inidir[0]=semiradius*cos(pt_theta);
     inidir[1]=semiradius*sin(pt_theta);
     inidir[2]=pt_z;
-    
+
     iter=(int) (gsl_rng_uniform(ran)*(double)N_RAN_PER_SEGMENT); // can have values in [0,1,..,N_RAN_PER_SEGMENT-1]
     ip_at_line=(int) iphot/g[id].numNeigh;
     segment=(N_RAN_PER_SEGMENT*(ip_at_line-np_per_line/2.)+iter)/(double)(np_per_line*N_RAN_PER_SEGMENT);
@@ -208,28 +244,42 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
     dir=sortangles(inidir,id,g,ran);
     here=g[id].id;
     there=g[here].neigh[dir]->id;
+#ifdef OLD_RT
     deltav=segment*4.3*g[id].dopb+veloproject(g[id].dir[dir].xn,vel);
-    
+#else
+    deltav=segment*4.3*g[id].dopb+veloproject(inidir,vel);
+#endif
     /* Photon propagation loop */
     do{
       if(firststep){
         firststep=0;				
-        ds=g[here].ds[dir]/2.;
+#ifdef OLD_RT
+        ds=0.5*g[here].ds[dir];
+#else
+	ds=0.5*g[here].ds[dir]*(inidir[0]*g[here].dir[dir].xn[0]+inidir[1]*g[here].dir[dir].xn[1]+inidir[2]*g[here].dir[dir].xn[2]);
+        ds_prev=ds;
+#endif
         halfFirstDs[iphot]=ds;
         for(l=0;l<par->nSpecies;l++){
-          if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
-          else velocityspline_lin(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
+          if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l],inidir);
+          else velocityspline_lin(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l],inidir);
           mp[l].vfac[iphot]=vfac[0];
         }
-        for(l=0;l<3;l++) x[l]=g[here].x[l]+(g[here].dir[dir].xn[l] * g[id].ds[dir]/2.);
+        for(l=0;l<3;l++) x[l]=g[here].x[l]+(g[here].dir[dir].xn[l] * 0.5*g[id].ds[dir]);
       } else {
+#ifdef OLD_RT
         ds=g[here].ds[dir];
+#else
+	ds=ds_prev;
+	ds_prev=0.5*g[here].ds[dir]*(inidir[0]*g[here].dir[dir].xn[0]+inidir[1]*g[here].dir[dir].xn[1]+inidir[2]*g[here].dir[dir].xn[2]);
+        ds+=ds_prev;
+#endif
         for(l=0;l<3;l++) x[l]=g[here].x[l];
       }
       
       for(l=0;l<par->nSpecies;l++){
-        if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
-        else velocityspline_lin(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
+        if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l],inidir);
+        else velocityspline_lin(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l],inidir);
       }
       
       for(iline=0;iline<nlinetot;iline++){
@@ -259,8 +309,8 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
           alpha=0.;
           for(jline=0;jline<sizeof(matrix)/sizeof(blend);jline++){
             if(matrix[jline].line1 == jline || matrix[jline].line2 == jline){	
-              if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[counta[jline]].binv,deltav-matrix[jline].deltav,&vblend);
-              else velocityspline_lin(g,here,dir,g[id].mol[counta[jline]].binv,deltav-matrix[jline].deltav,&vblend);	
+              if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[counta[jline]].binv,deltav-matrix[jline].deltav,&vblend,inidir);
+              else velocityspline_lin(g,here,dir,g[id].mol[counta[jline]].binv,deltav-matrix[jline].deltav,&vblend,inidir);
               sourceFunc_line(&jnu,&alpha,m,vblend,g,here,counta[jline],countb[jline]);
               dtau=alpha*ds;
               if(dtau < -30) dtau = -30;
@@ -281,11 +331,19 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
         /* End of line blending part */
       }
       
+#ifdef OLD_RT
       dir=sortangles(inidir,there,g,ran);
       here=there;
       there=g[here].neigh[dir]->id;
     } while(!g[there].sink);
-    
+#else
+      if (!g[here].sink) {
+         dir=sortangles(inidir,there,g,ran);
+         here=there;
+         there=g[here].neigh[dir]->id;
+      }
+    } while(!g[here].sink);
+#endif
     /* Add cmb contribution */
     if(m[0].cmb[0]>0.){
       for(iline=0;iline<nlinetot;iline++){


### PR DESCRIPTION
The values (e.g. for speed of light) were slightly off from currently defined/experimentally determined SI values.

Added parentheses around preprocessor definitions to make sure that e.g. constant HCKB=100.*HPLANCK*CLIGHT/KBOLTZ is computed at compile time. This also makes the code slightly faster.