### PR TITLE
Treegrid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,24 +49,24 @@ endif
 ##
 
 TARGET  = lime.x 
-CC		= gcc -fopenmp
-SRCS    = src/aux.c src/messages.c src/grid.c src/LTEsolution.c   \
-		  src/main.c src/molinit.c src/photon.c src/popsin.c    \
-		  src/popsout.c src/predefgrid.c src/ratranInput.c      \
+CC	= gcc -fopenmp
+SRCS    = src/aux.c src/messages.c src/grid.c src/LTEsolution.c \
+	  src/main.c src/molinit.c src/photon.c src/popsin.c    \
+	  src/popsout.c src/predefgrid.c src/ratranInput.c      \
           src/raytrace.c src/smooth.c src/sourcefunc.c          \
-		  src/stateq.c src/statistics.c src/magfieldfit.c       \
-		  src/stokesangles.c src/writefits.c src/weights.c      \
-		  src/velospline.c src/getclosest.c  \
-		  src/tcpsocket.c src/defaults.c src/fastexp.c
+	  src/stateq.c src/statistics.c src/magfieldfit.c       \
+	  src/stokesangles.c src/writefits.c src/weights.c      \
+	  src/velospline.c src/getclosest.c  \
+	  src/tcpsocket.c src/defaults.c src/fastexp.c
 MODELS  = model.c
-OBJS    = src/aux.o src/messages.o src/grid.o src/LTEsolution.o   \
-		  src/main.o src/molinit.o src/photon.o src/popsin.o    \
-		  src/popsout.o src/predefgrid.o src/raytrace.o         \
-		  src/ratranInput.o src/smooth.o src/sourcefunc.o       \
-		  src/stateq.o src/statistics.o src/magfieldfit.o       \
-		  src/stokesangles.o src/writefits.o src/weights.o      \
-		  src/velospline.o src/getclosest.o  \
-		  src/tcpsocket.o src/defaults.o src/fastexp.o
+OBJS    = src/aux.o src/messages.o src/grid.o src/LTEsolution.o \
+	  src/main.o src/molinit.o src/photon.o src/popsin.o    \
+	  src/popsout.o src/predefgrid.o src/raytrace.o         \
+	  src/ratranInput.o src/smooth.o src/sourcefunc.o       \
+	  src/stateq.o src/statistics.o src/magfieldfit.o       \
+	  src/stokesangles.o src/writefits.o src/weights.o      \
+	  src/velospline.o src/getclosest.o  \
+	  src/tcpsocket.o src/defaults.o src/fastexp.o
 MODELO 	= src/model.o
 
 #CCFLAGS = -O3 -falign-loops=16 -fno-strict-aliasing -DTEST -DFASTEXP -DNO_NCURSES

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ SRCS    = src/aux.c src/messages.c src/grid.c src/LTEsolution.c \
 	  src/popsout.c src/predefgrid.c src/ratranInput.c      \
           src/raytrace.c src/smooth.c src/sourcefunc.c          \
 	  src/stateq.c src/statistics.c src/magfieldfit.c       \
-	  src/stokesangles.c src/writefits.c src/weights.c      \
+	  src/stokesangles.c src/writefits.c src/random_points.c\
 	  src/velospline.c src/getclosest.c  \
 	  src/tcpsocket.c src/defaults.c src/fastexp.c
 MODELS  = model.c
@@ -64,7 +64,7 @@ OBJS    = src/aux.o src/messages.o src/grid.o src/LTEsolution.o \
 	  src/popsout.o src/predefgrid.o src/raytrace.o         \
 	  src/ratranInput.o src/smooth.o src/sourcefunc.o       \
 	  src/stateq.o src/statistics.o src/magfieldfit.o       \
-	  src/stokesangles.o src/writefits.o src/weights.o      \
+	  src/stokesangles.o src/writefits.o src/random_points.o\
 	  src/velospline.o src/getclosest.o  \
 	  src/tcpsocket.o src/defaults.o src/fastexp.o
 MODELO 	= src/model.o

--- a/example/model.c
+++ b/example/model.c
@@ -23,6 +23,7 @@ input(inputPars *par, image *img){
   par->dust				= "jena_thin_e6.tab";
   par->moldatfile[0] 	= "hco+@xpol.dat";
   par->antialias		= 4;
+//  par->samplingAlgorithm	= 1; // 0= the previous 'flattened rejection' algorithm; 1= the new 'tree' algorithm.
   par->sampling			= 2; // log distr. for radius, directions distr. uniformly on a sphere.
 
   par->outputfile 		= "populations.pop";

--- a/example/model.c
+++ b/example/model.c
@@ -51,7 +51,7 @@ density(double x, double y, double z, double *density){
   /*
    * Define variable for radial coordinate
    */
-  double r;
+  double r, rMin=0.5*AU;
   /*
    * Calculate radial distance from origin
    */
@@ -60,7 +60,10 @@ density(double x, double y, double z, double *density){
    * Calculate a spherical power-law density profile
    * (Multiply with 1e6 to go to SI-units)
    */
-  density[0] = 1.5e6*pow(r/(300*AU),-1.5)*1e6;
+  if(r<rMin)
+    density[0] = 1.5e6*pow(rMin/(300*AU),-1.5)*1e6;
+  else
+    density[0] = 1.5e6*pow(r/(300*AU),-1.5)*1e6;
 }
 
 /******************************************************************************/

--- a/example/model.c
+++ b/example/model.c
@@ -29,6 +29,7 @@ input(inputPars *par, image *img){
   par->outputfile 		= "populations.pop";
   par->binoutputfile 	= "restart.pop";
   par->gridfile			= "grid.vtk";
+//  par->minPointNumDensity	= 1000; // You should specify this in terms of the number of points in the spherical model volume.
 
 //  par->numDensityMaxima = 1;
 //  par->densityMaxLoc[0].x[0] = 0.0;

--- a/example/model.c
+++ b/example/model.c
@@ -30,6 +30,17 @@ input(inputPars *par, image *img){
   par->binoutputfile 	= "restart.pop";
   par->gridfile			= "grid.vtk";
 
+//  par->numDensityMaxima = 1;
+//  par->densityMaxLoc[0].x[0] = 0.0;
+//  par->densityMaxLoc[0].x[1] = 0.0;
+//  par->densityMaxLoc[0].x[2] = 0.0;
+
+//  double *vals;
+//  vals=malloc(sizeof(double)*1);
+//  density(0.0,0.0,0.0,vals);
+//  par->densityMaxValue[0] = vals[0];
+//  free(vals);
+
   /*
    * Definitions for image #0. Add blocks for additional images.
    */

--- a/src/aux.c
+++ b/src/aux.c
@@ -19,6 +19,7 @@ parseInput(inputPars *par, image **img, molData **m){
   int i,id;
   double BB[3];
   double cosPhi,sinPhi,cosTheta,sinTheta;
+  extern double modelRadiusSquared;
 
   /* Set default values */
   par->dust  	    = NULL;
@@ -31,8 +32,8 @@ parseInput(inputPars *par, image **img, molData **m){
 
   par->tcmb = 2.728;
   par->lte_only=0;
-  par->init_lte=0;
-  par->sampling=2;
+  par->samplingAlgorithm=0;
+  par->sampling=2; // Now only accessed if par->samplingAlgorithm==0.
   par->blend=0;
   par->antialias=1;
   par->polarization=0;
@@ -103,6 +104,8 @@ parseInput(inputPars *par, image **img, molData **m){
   par->radiusSqu=par->radius*par->radius;
   par->minScaleSqu=par->minScale*par->minScale;
   if(par->pregrid!=NULL) par->doPregrid=1;
+
+  modelRadiusSquared = par->radiusSqu; // this value is copied here to an external variable so the random grid generator functions can find it.
 
   /*
 Now we need to calculate the cutoff value used in calcSourceFn(). The issue is to decide between

--- a/src/aux.c
+++ b/src/aux.c
@@ -42,6 +42,7 @@ parseInput(inputPars *par, image **img, molData **m){
   par->doPregrid=0;
   par->nThreads=0;
   par->numDensityMaxima=0;
+  par->minPointNumDensity=0;
 
   /* Allocate space for output fits images */
   (*img)=malloc(sizeof(image)*MAX_NSPECIES);

--- a/src/aux.c
+++ b/src/aux.c
@@ -41,6 +41,7 @@ parseInput(inputPars *par, image **img, molData **m){
   par->sinkPoints=0;
   par->doPregrid=0;
   par->nThreads=0;
+  par->numDensityMaxima=0;
 
   /* Allocate space for output fits images */
   (*img)=malloc(sizeof(image)*MAX_NSPECIES);
@@ -104,6 +105,7 @@ parseInput(inputPars *par, image **img, molData **m){
   par->radiusSqu=par->radius*par->radius;
   par->minScaleSqu=par->minScale*par->minScale;
   if(par->pregrid!=NULL) par->doPregrid=1;
+  if(par->numDensityMaxima>MAX_N_HIGH) par->numDensityMaxima=MAX_N_HIGH;
 
   modelRadiusSquared = par->radiusSqu; // this value is copied here to an external variable so the random grid generator functions can find it.
 

--- a/src/aux.c
+++ b/src/aux.c
@@ -48,7 +48,7 @@ parseInput(inputPars *par, image **img, molData **m){
     (*img)[id].filename=NULL;
     par->moldatfile[id]=NULL;
   }
-  input(par, *img);
+  input(par, *img); // First call to input().
   id=-1;
   while((*img)[++id].filename!=NULL);
   par->nImages=id;
@@ -93,7 +93,7 @@ parseInput(inputPars *par, image **img, molData **m){
     (*img)[i].freq=-1.;
     (*img)[i].bandwidth=-1.;
   }
-  input(par,*img);
+  input(par,*img); // Second call to input().
 
   if(par->nThreads == 0){ // Hmm. Really ought to have a separate boolean parameter.
     par->nThreads = NTHREADS;

--- a/src/grid.c
+++ b/src/grid.c
@@ -516,86 +516,66 @@ getMass(inputPars *par, struct grid *g, const gsl_rng *ran){
 
 void
 buildGrid(inputPars *par, struct grid *g){
-  double lograd;		/* The logarithm of the model radius		*/
-  double logmin;	    /* Logarithm of par->minScale				*/
-  double r,theta,phi,sinPhi,x,y,z,semiradius;	/* Coordinates								*/
-  double temp;
-  int k=0,i;            /* counters									*/
-  int flag;
+  const gsl_rng_type *ranNumGenType = gsl_rng_ranlxs2;
+  int i, desiredNumPoints=par->pIntensity, k;
+  double theta, semiradius, x, y, z;
+  double vals[99]; //**** define MAX_N_COLL_PARTNERS in lime.h and dimension it to that rather than 99.
+  double *outRandDensities=NULL;
+  locusType *outRandLocations=NULL;
+  extern double densityNormalizer;
+  extern int numCollisionPartners;
 
-  gsl_rng *ran = gsl_rng_alloc(gsl_rng_ranlxs2);	/* Random number generator */
+  gsl_rng *randGen = gsl_rng_alloc(ranNumGenType);	/* Random number generator */
 #ifdef TEST
-  gsl_rng_set(ran,342971);
+  gsl_rng_set(randGen,342971);
 #else
-  gsl_rng_set(ran,time(0));
+  gsl_rng_set(randGen,time(0));
 #endif  
-  
-  lograd=log10(par->radius);
-  logmin=log10(par->minScale);
 
-  /* Sample pIntensity number of points */
-  for(k=0;k<par->pIntensity;k++){
-    temp=gsl_rng_uniform(ran);
-    flag=0;
-    /* Pick a point and check if we like it or not */
-    do{
-      if(par->sampling==0){
-        r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));
-        theta=2.*PI*gsl_rng_uniform(ran);
-        phi=PI*gsl_rng_uniform(ran);
-        sinPhi=sin(phi);
-        x=r*cos(theta)*sinPhi;
-        y=r*sin(theta)*sinPhi;
-        if(DIM==3) z=r*cos(phi);
-        else z=0.;
-      } else if(par->sampling==1){
-        x=(2*gsl_rng_uniform(ran)-1)*par->radius;
-        y=(2*gsl_rng_uniform(ran)-1)*par->radius;
-        if(DIM==3) z=(2*gsl_rng_uniform(ran)-1)*par->radius;
-        else z=0;
-      } else if(par->sampling==2){
-        r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));
-        theta=2.*PI*gsl_rng_uniform(ran);
-        if(DIM==3) {
-          z=2*gsl_rng_uniform(ran)-1.;
-          semiradius=r*sqrt(1.-z*z);
-          z*=r;
-        } else {
-          z=0.;
-          semiradius=r;
-        }
-        x=semiradius*cos(theta);
-        y=semiradius*sin(theta);
-      } else {
-        if(!silent) bail_out("Don't know how to sample model");
-        exit(1);
-      }
-      if((x*x+y*y+z*z)<par->radiusSqu) flag=pointEvaluation(par,temp,x,y,z);
-    } while(!flag);
-    /* Now pointEvaluation has decided that we like the point */
+  outRandDensities = malloc(sizeof(double   )*desiredNumPoints); // Not used at present; and in fact they are not useful outside this routine, because they are not the values of the physical density at that point, just what densityFunc3D() returns, which is not necessarily the same thing.
+  outRandLocations = malloc(sizeof(locusType)*desiredNumPoints);
 
+  numCollisionPartners = par->collPart; // set here so densityFunc3D() can access it.
+
+  if(par->samplingAlgorithm==0){
+//    printf("Grid point sampling by rejection.\n");
+
+    density(par->minScale,par->minScale,par->minScale,vals);
+    for (i=0;i<par->collPart;i++) densityNormalizer += vals[i];
+    if (densityNormalizer<=0.){
+      if(!silent) bail_out("Error: Sum of reference densities equals 0");
+      exit(1);
+    }
+
+    randomsViaRejection(par, desiredNumPoints, randGen, densityFunc3D, outRandLocations, outRandDensities);
+
+  } else {
+    if(!silent) bail_out("Unrecognized sampling algorithm.");
+    exit(1);
+  }
+
+  for(k=0;k<desiredNumPoints;k++){
     /* Assign values to the k'th grid point */
-    /* I don't think we actually need to do this here... */
     g[k].id=k;
-    g[k].x[0]=x;
-    g[k].x[1]=y;
-    if(DIM==3) g[k].x[2]=z;
+    g[k].x[0]=outRandLocations[k].x[0];
+    g[k].x[1]=outRandLocations[k].x[1];
+    if(DIM==3) g[k].x[2]=outRandLocations[k].x[2];
     else g[k].x[2]=0.;
-
     g[k].sink=0;
+
     /* This next step needs to be done, even though it looks stupid */
     g[k].dir=malloc(sizeof(point)*1);
     g[k].ds =malloc(sizeof(double)*1);
     g[k].neigh =malloc(sizeof(struct grid *)*1);
-    if(!silent) progressbar((double) k/((double)par->pIntensity-1), 4);
   }
+
   /* end model grid point assignment */
   if(!silent) done(4);
 
   /* Add surface sink particles */
   for(i=0;i<par->sinkPoints;i++){
-    theta=gsl_rng_uniform(ran)*2*PI;
-    if(DIM==3) z=2*gsl_rng_uniform(ran)-1.;
+    theta=gsl_rng_uniform(randGen)*2*PI;
+    if(DIM==3) z=2*gsl_rng_uniform(randGen)-1.;
     else z=0.;
     semiradius=sqrt(1.-z*z);
     x=semiradius*cos(theta);
@@ -624,12 +604,15 @@ buildGrid(inputPars *par, struct grid *g){
     abundance(  g[i].x[0],g[i].x[1],g[i].x[2], g[i].abun);
   }
 
-  //	getArea(par,g, ran);
-  //	getMass(par,g, ran);
+  //	getArea(par,g, randGen);
+  //	getMass(par,g, randGen);
   getVelosplines(par,g);
   dumpGrid(par,g);
 
-  gsl_rng_free(ran);
+  free(outRandLocations);
+  free(outRandDensities);
+  gsl_rng_free(randGen);
+
   if(!silent) done(5);
 }
 

--- a/src/grid.c
+++ b/src/grid.c
@@ -521,8 +521,8 @@ buildGrid(inputPars *par, struct grid *g){
   double theta,semiradius,x,y,z,fieldVolume,sumDensity,maxDensity;
   double vals[99]; //**** define MAX_N_COLL_PARTNERS in lime.h and dimension it to that rather than 99.
   double *fieldOrigin=NULL, *fieldDimensions=NULL, *randomDensities=NULL;
-  double *outRandDensities=NULL;
-  locusType *outRandLocations=NULL, *randomLocations=NULL;
+  double *outRandDensities=NULL, *highPointDensities=NULL;
+  locusType *outRandLocations=NULL, *randomLocations=NULL, *highPointLocations=NULL;
   extern double densityNormalizer;
   extern int numCollisionPartners;
 
@@ -560,18 +560,31 @@ buildGrid(inputPars *par, struct grid *g){
       fieldDimensions[di] = 2.0*par->radius;
     }
 
+    if(par->numDensityMaxima>0){
+      highPointLocations = malloc(sizeof(locusType)*par->numDensityMaxima);
+      highPointDensities = malloc(sizeof(double   )*par->numDensityMaxima);
+      for(i=0;i<par->numDensityMaxima;i++){
+        for(di=0;di<DIM;di++){
+          highPointLocations[i].x[di] = par->densityMaxLoc[i].x[di];
+        }
+        highPointDensities[i] = par->densityMaxValue[i];
+      }
+    }
+
     initializeTree(fieldOrigin, fieldDimensions, desiredNumPoints\
       , randGen, densityFunc3D, &numSubFields, &fieldVolume, &sumDensity, &maxDensity\
-      , 0, NULL, NULL\
+      , par->numDensityMaxima, highPointLocations, highPointDensities\
       , N_TREE_RANDOMS, &randomLocations, &randomDensities);
 
     randomsViaTree(levelI, numSubFields, fieldOrigin, fieldDimensions\
       , fieldVolume, desiredNumPoints, startI\
-      , 0, NULL, NULL\
+      , par->numDensityMaxima, highPointLocations, highPointDensities\
       , N_TREE_RANDOMS, randomLocations, randomDensities, sumDensity, maxDensity\
       , randGen, densityFunc3D, NULL, outRandLocations\
       , outRandDensities, 0);
 
+    if(highPointLocations!=NULL) free(highPointLocations);
+    if(highPointDensities!=NULL) free(highPointDensities);
     free(randomDensities);
     free(randomLocations);
     free(fieldDimensions);

--- a/src/lime.h
+++ b/src/lime.h
@@ -76,7 +76,13 @@
 #define N_RAN_PER_SEGMENT       3
 #define FAST_EXP_MAX_TAYLOR	3
 #define FAST_EXP_NUM_BITS	8
+#define DENSITY_POWER		0.2
 
+
+// This should replace the 'point' type. Rather than have x[] as well as xn[], better to have two sorts of dir, both of type locus, in struct grid.
+typedef struct {
+  double x[DIM];
+} locusType;
 
 /* input parameters */
 typedef struct {
@@ -87,7 +93,7 @@ typedef struct {
   char *pregrid;
   char *restart;
   char *dust;
-  int sampling,collPart,lte_only,init_lte,antialias,polarization,doPregrid,nThreads;
+  int samplingAlgorithm,sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads;
   char **moldatfile;
 } inputPars;
 
@@ -190,6 +196,7 @@ void   	binpopsout(inputPars *, struct grid *, molData *);
 void   	buildGrid(inputPars *, struct grid *);
 void    calcSourceFn(double dTau, const inputPars *par, double *remnantSnu, double *expDTau);
 void	continuumSetup(int, image *, molData *, inputPars *, struct grid *);
+double	densityFunc3D(locusType location);
 void	distCalc(inputPars *, struct grid *);
 void	fit_d1fi(double, double, double*);
 void    fit_fi(double, double, double*);
@@ -220,10 +227,11 @@ void	qhull(inputPars *, struct grid *);
 void  	photon(int, struct grid *, molData *, int, const gsl_rng *,inputPars *,blend *,gridPointData *,double *);
 void	parseInput(inputPars *, image **, molData **);
 double 	planckfunc(int, double, molData *, int);
-int     pointEvaluation(inputPars *,double, double, double, double);
 void   	popsin(inputPars *, struct grid **, molData **, int *);
 void   	popsout(inputPars *, struct grid *, molData *);
 void	predefinedGrid(inputPars *, struct grid *);
+void	randomsViaRejection(inputPars*, unsigned int, gsl_rng*, double (*numberDensyFunc)(locusType), locusType*\
+  , double*);
 double 	ratranInput(char *, char *, double, double, double);
 void   	raytrace(int, inputPars *, struct grid *, molData *, image *);
 void	report(int, inputPars *, struct grid *);

--- a/src/lime.h
+++ b/src/lime.h
@@ -77,6 +77,10 @@
 #define FAST_EXP_MAX_TAYLOR	3
 #define FAST_EXP_NUM_BITS	8
 #define DENSITY_POWER		0.2
+#define N_TREE_RANDOMS		1000	/* Arbitrary - experiment around a bit to find a good value. */
+#define MAX_RECURSION           20	/* >20 is not safe with single-precision arithmetic. */
+#define MAX_N_TRIALS_TREE	1000	/* Arbitrary - experiment to find a good value. */
+#define TREE_DITHER		0.1	/* must be >=0, <1. */
 
 
 // This should replace the 'point' type. Rather than have x[] as well as xn[], better to have two sorts of dir, both of type locus, in struct grid.
@@ -88,12 +92,12 @@ typedef struct {
 typedef struct {
   double radius,radiusSqu,minScale,minScaleSqu,tcmb,taylorCutoff;
   int ncell,sinkPoints,pIntensity,nImages,nSpecies,blend;
+  int samplingAlgorithm,sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads;
   char *outputfile, *binoutputfile, *inputfile;
   char *gridfile;
   char *pregrid;
   char *restart;
   char *dust;
-  int samplingAlgorithm,sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads;
   char **moldatfile;
 } inputPars;
 
@@ -215,6 +219,8 @@ void	getclosest(double, double, double, long *, long *, double *, double *, doub
 void	getVelosplines(inputPars *, struct grid *);
 void	getVelosplines_lin(inputPars *, struct grid *);
 void	gridAlloc(inputPars *, struct grid **);
+void	initializeTree(double*, double*, unsigned int, gsl_rng*\
+  , double (*numberDensyFunc)(locusType), int*, double*, double*, double*, int, locusType*, double*, int, locusType**, double **);
 void   	kappa(molData *, struct grid *, inputPars *,int);
 void	levelPops(molData *, inputPars *, struct grid *, int *);
 void	line_plane_intersect(struct grid *, double *, int , int *, double *, double *, double);
@@ -230,6 +236,9 @@ double 	planckfunc(int, double, molData *, int);
 void   	popsin(inputPars *, struct grid **, molData **, int *);
 void   	popsout(inputPars *, struct grid *, molData *);
 void	predefinedGrid(inputPars *, struct grid *);
+void	randomsViaTree(int, int, double*, double*, double, unsigned int, unsigned int, int\
+  , locusType*, double*, int, locusType*, double*, double, double, gsl_rng*, double (*numberDensyFunc)(locusType)\
+  , void (*monitorFunc)(locusType*, double*, unsigned int, unsigned int, double*, double*), locusType*, double*, int);
 void	randomsViaRejection(inputPars*, unsigned int, gsl_rng*, double (*numberDensyFunc)(locusType), locusType*\
   , double*);
 double 	ratranInput(char *, char *, double, double, double);

--- a/src/lime.h
+++ b/src/lime.h
@@ -92,7 +92,7 @@ typedef struct {
 /* input parameters */
 typedef struct {
   double radius,radiusSqu,minScale,minScaleSqu,tcmb,taylorCutoff,densityMaxValue[MAX_N_HIGH];
-  int ncell,sinkPoints,pIntensity,nImages,nSpecies,blend;
+  int ncell,sinkPoints,pIntensity,nImages,nSpecies,blend,minPointNumDensity;
   int samplingAlgorithm,sampling,collPart,lte_only,antialias,polarization;
   int doPregrid,nThreads,numDensityMaxima;
   char *outputfile, *binoutputfile, *inputfile;

--- a/src/lime.h
+++ b/src/lime.h
@@ -81,6 +81,7 @@
 #define MAX_RECURSION           20	/* >20 is not safe with single-precision arithmetic. */
 #define MAX_N_TRIALS_TREE	1000	/* Arbitrary - experiment to find a good value. */
 #define TREE_DITHER		0.1	/* must be >=0, <1. */
+#define MAX_N_HIGH		10
 
 
 // This should replace the 'point' type. Rather than have x[] as well as xn[], better to have two sorts of dir, both of type locus, in struct grid.
@@ -90,15 +91,17 @@ typedef struct {
 
 /* input parameters */
 typedef struct {
-  double radius,radiusSqu,minScale,minScaleSqu,tcmb,taylorCutoff;
+  double radius,radiusSqu,minScale,minScaleSqu,tcmb,taylorCutoff,densityMaxValue[MAX_N_HIGH];
   int ncell,sinkPoints,pIntensity,nImages,nSpecies,blend;
-  int samplingAlgorithm,sampling,collPart,lte_only,antialias,polarization,doPregrid,nThreads;
+  int samplingAlgorithm,sampling,collPart,lte_only,antialias,polarization;
+  int doPregrid,nThreads,numDensityMaxima;
   char *outputfile, *binoutputfile, *inputfile;
   char *gridfile;
   char *pregrid;
   char *restart;
   char *dust;
   char **moldatfile;
+  locusType densityMaxLoc[MAX_N_HIGH];
 } inputPars;
 
 /* Molecular data: shared attributes */

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,7 @@ double EXP_TABLE_3D[1][1][1];
 #endif
 
 /* Define the following here so they can be accessed from other functions. */ 
-double modelRadiusSquared=0.0, densityNormalizer=0.0;
+double modelRadiusSquared=0.0, densityNormalizer=0.0, minDensity=0.0;
 int numCollisionPartners=0;
 
 int main () {

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,10 @@ double EXP_TABLE_2D[1][1]; // nominal definitions so the fastexp.c module will c
 double EXP_TABLE_3D[1][1][1];
 #endif
 
+/* Define the following here so they can be accessed from other functions. */ 
+double modelRadiusSquared=0.0, densityNormalizer=0.0;
+int numCollisionPartners=0;
+
 int main () {
   int i;
   int initime=time(0);

--- a/src/random_points.c
+++ b/src/random_points.c
@@ -8,6 +8,447 @@
 
 #include "lime.h"
 
+void initializeTree(double *fieldOrigin, double *fieldDimensions\
+  , unsigned int desiredNumPoints, gsl_rng *randGen, double (*numberDensyFunc)(locusType)\
+  , int *numSubFields, double *fieldVolume, double *sumDensity, double *maxDensity\
+  , int numHighPoints, locusType *highPointLocations, double *highPointDensities\
+  , int numInRandoms, locusType **inRandLocations, double **inRandDensities){
+
+  int di, i;
+  double x;
+  locusType location;
+
+  *fieldVolume = 1.0;
+  *numSubFields = 1;
+  for(di=0;di<DIM;di++){
+    *fieldVolume *= fieldDimensions[di];
+    *numSubFields *= 2;
+  }
+
+  /* Generate the evenly-distributed random points:
+  */
+  (*inRandDensities) = malloc(sizeof(double   )*numInRandoms);
+  (*inRandLocations) = malloc(sizeof(locusType)*numInRandoms);
+
+  *sumDensity = 0.0;
+  for(i=0;i<numInRandoms;i++){
+    for(di=0;di<DIM;di++){
+      x = gsl_rng_uniform(randGen);
+      (*inRandLocations)[i].x[di] = x;
+      location.x[di] = fieldOrigin[di] + fieldDimensions[di]*x;
+    }
+
+    (*inRandDensities)[i] = numberDensyFunc(location);
+    *sumDensity += (*inRandDensities)[i];
+  }
+
+  /* Find the maximum density:
+  */
+  i = 0;
+  *maxDensity = (*inRandDensities)[i];
+  for(i=1;i<numInRandoms;i++){
+    if ((*inRandDensities)[i]>(*maxDensity))
+      *maxDensity = (*inRandDensities)[i];
+  }
+
+  if(highPointDensities!=NULL){
+    for(i=0;i<numHighPoints;i++)
+      if (highPointDensities[i]>(*maxDensity))
+        *maxDensity = highPointDensities[i];
+  }
+}
+
+void randomsViaTree(int levelI, int numSubFields, double *fieldOrigin, double *fieldDimensions\
+  , double fieldVolume, unsigned int desiredNumPoints, unsigned int startI\
+  , int numHighPoints, locusType *highPointLocations, double *highPointDensities\
+  , int numInRandoms, locusType *inRandLocations, double *inRandDensities\
+  , double sumDensity, double maxDensity, gsl_rng *randGen, double (*numberDensyFunc)(locusType)\
+  , void (*monitorFunc)(locusType*, double*, unsigned int, unsigned int, double*, double*)\
+  , locusType *outRandLocations, double *outRandDensities, int verbosity){
+
+  /*
+This function is designed to be called recursively to choose random points having a distribution which follows some user-supplied number-density function, within an orthotopic space. (An orthotope is a generalization to N dimensions of the concept of a rectangle.)
+
+Each function call is supplied with the dimensions of its orthotope, the required number of points, and a function which returns a number-density value for a location argument. Other arguments are also supplied which are described later. The function must decide whether to further divide the orthotope, cycling then through recursive calls for all these sub-orthotopes, or to go ahead and generate its required number of points via the rejection method.
+
+The points are loaded into, and thus returned in, the appropriate series of entries of the pointers outRandLocations and outRandDensities.
+
+The only criterion in deciding whether to subdivide or not is whether the expected amount of work to do in trying points exceeds a preset cutoff value. Essentially this is proportional to the number of points desired from the subField divided by the 'filling fraction' of the density function. A density function that is highly peaked in the present field will likely have a small filling fraction and thus likely require subdivision.
+
+Explanation of the input arguments:
+
+	- levelI: the current recursion depth.
+
+	- numSubFields: should be set to 2**DIM by the calling program. It would be safer to calculate it anew with each function call, but a bit slower; that's why I am trusting the caller.
+
+	- fieldOrigin: a vector of length DIM giving the origin of the present orthotope (aka field).
+
+	- fieldDimensions: a vector of length DIM giving the side lengths of the present orthotope.
+
+	- fieldVolume: the volume of the present orthotope. It would be safer (but slower) to calculate it anew with each function call.
+
+	- desiredNumPoints: the number of output random points desired in the present field.
+
+	- startI: this is the index of the first unfilled values in the vectors of points outRandLocations and outRandDensities (see below).
+
+	- numHighPoints: the number of entries (can be 0) in the following:
+
+	- highPointLocations, highPointDensities: these lists allow the user to specify maxima of the number-density function. This is useful in the case that these peaks in the function are so narrow that they are unlikely to be properly sampled by the algorithm, at least in the early stages of subField division. Setting the number-density maximum thus at its true peak value(s) ensures that fields into which the highPointLocations fall will correctly assess the need to subdivide.
+
+	- numInRandoms: the length of the list of inRandLocations and inRandDensities.
+
+	- inRandLocations: a list of random positions distributed evenly through a dimension-N orthotope of unit side lengths. The same set of points, appropriately scaled and offset, is used for all the sub-fields. This is probably quicker than calculating new random positions for each sub-field, and there doesn't seem to be any reason not to reuse the one set of positions.
+
+	- inRandDensities: values of the number-density function evaluated at the inRandLocations. These are of course re-evaluated for each sub-field.
+
+	- sumDensity: the sum of the values of inRandDensities. (Note that highPointDensities are not included.)
+
+	- maxDensity: the maximum of inRandDensities (and here highPointDensities are also included, if non-NULL and numHighPoints>0).
+
+	- randGen: random number generator.
+
+	- numberDensyFunc: this is a user-supplied function which must take a locusType argument and return a double. Note that it is assumed that numberDensyFunc 'knows' the value of DIM a priori.
+
+	- monitorFunc: this is optional: if not set to NULL, it should be a user-supplied function which takes the arguments shown. The purpose of this is essentially to aid in bug finding and/or logging.
+
+	- outRandLocations, outRandDensities: the pointers which are filled by successive calls to the function randomsViaTree().
+
+
+Note that the following are expected to be either macros defined in a header file or globally accessible variables:
+	* MAX_RECURSION: limit on the depth of recursion.
+
+	* DIM: dimensionality of the space being populated.
+
+	* MAX_N_TRIALS_TREE: essentially a limit on the number of rejection-method discards permitted. Cells for which the estimated number of discards would be higher than this are subdivided.
+
+	* TREE_DITHER: when subdividing, the field dimensions are divided in two, but with this dither applied. It must be less than unity.
+  */
+
+  int doSubdivide, expectedNumTrials, di, sci, ppi, pointAllocated;
+  int subFieldExcluded, localStartI, piIn, piOut, lastPiOut, timeOut;
+  int *subFieldNumHighPoints=NULL, *subFieldThisPoint=NULL, *indices=NULL;
+  unsigned int remainingDesNum;
+  unsigned int *subFieldDesNumPoints=NULL;
+  double meanDensity, dither, xLo, xHi, totalDensityIntegral, remainingDensy;
+  double probability, acceptanceChance, x, density;
+  double *sideMidPoints=NULL, *sideMaxPoints=NULL, *subFieldVolumes=NULL;
+  double *subFieldMaxDensities=NULL, *subFieldSumDensities=NULL;
+  double *subFieldDensityIntegrals=NULL;
+  double **subFieldOrigins=NULL, **subFieldLengths=NULL, **subFieldDensities=NULL;
+  double **subFieldHighDensities=NULL;
+  locusType location, **subFieldHighLocations=NULL;
+
+  char spaces[2*levelI+1];
+
+  if (verbosity>0){
+    memset(spaces,' ',2*levelI);
+    spaces[2*levelI]='\0';
+    printf("\n%sEntering randomsViaTree, level %d, startI=%d\n", spaces, levelI, startI);
+  }
+
+  if (desiredNumPoints<1) { // should test this before entering the function, but just to be sure...
+    if (verbosity>0) printf("%sdesiredNumPoints==0!\n", spaces);
+    if (verbosity>0) printf("%sLeaving randomsViaTree, level %d\n", spaces, levelI);
+    exit(1);
+  }
+
+  /*. . . . . . . . . . . . . .  . . . . . . . . . . . . . . . . . . . .*/
+  /* Decide whether to sub-divide.
+  */
+  if (verbosity>2) printf("%sDecide whether to subdivide.\n", spaces);
+  doSubdivide = 0; // default
+  if (levelI<MAX_RECURSION){
+//****    if sumDensity<=0.0 raise a 'bug' exception. This should not happen if desiredNumPoints>0.
+    meanDensity = sumDensity/(double)numInRandoms;
+    expectedNumTrials = (double)(desiredNumPoints)*maxDensity/meanDensity;
+    if (expectedNumTrials>MAX_N_TRIALS_TREE)
+      doSubdivide = 1;
+  }
+
+  /*. . . . . . . . . . . . . .  . . . . . . . . . . . . . . . . . . . .*/
+  if (doSubdivide){
+    if (verbosity>1) printf("%sSubdividing.\n", spaces);
+    if (verbosity>2) printf("%sCalculate origin and dimensions.\n", spaces);
+
+    /* Calculate the origin and dimensions for the sub-cubes:
+    */
+    sideMidPoints   = malloc(sizeof(double)*DIM);
+    sideMaxPoints   = malloc(sizeof(double)*DIM);
+    subFieldVolumes = malloc(sizeof(double)  *numSubFields);
+    subFieldOrigins = malloc(sizeof(double *)*numSubFields);
+    subFieldLengths = malloc(sizeof(double *)*numSubFields);
+    for(sci=0;sci<numSubFields;sci++){
+      subFieldOrigins[sci] = malloc(sizeof(double)*DIM);
+      subFieldLengths[sci] = malloc(sizeof(double)*DIM);
+    }
+
+    for(di=0;di<DIM;di++){
+      sideMaxPoints[di] = fieldOrigin[di] + fieldDimensions[di];
+      if (TREE_DITHER>0.0){
+        dither = 0.5*TREE_DITHER*(gsl_rng_uniform(randGen)-0.5)*fieldDimensions[di];
+        sideMidPoints[di] = fieldOrigin[di] + fieldDimensions[di]/2.0 + dither;
+//**** check it is within range? Nah just check dither is in [0,1). Also maybe warn if dither too close to 0 or 1?
+      }else
+        sideMidPoints[di] = fieldOrigin[di] + fieldDimensions[di]/2.0;
+    }
+
+    for(sci=0;sci<numSubFields;sci++){
+      subFieldVolumes[sci] = 1.0;
+      for(di=0;di<DIM;di++){
+        if (sci&(1<<di)){
+          /* Relies on the fact that each dimension is divided in 2. Take an example in which DIM==3. Here there are 3**2=8 subFields. The 6th subField has number 5 in the range 0 to 7; 5 in binary is 011; thus we take this to be the subField which is in the upper half of the X axis, the upper half of the Y axis, but the lower half of the Z axis (1, 1 and 0, starting from the LSB). */
+          xLo = sideMidPoints[di];
+          xHi = sideMaxPoints[di];
+        }else{
+          xLo = fieldOrigin[di];
+          xHi = sideMidPoints[di];
+        }
+
+        subFieldOrigins[sci][di] = xLo;
+        subFieldLengths[sci][di] = xHi - xLo;
+        subFieldVolumes[sci] *= subFieldLengths[sci][di];
+      }
+    }
+
+    /* Allocate the high points between subFields:
+    */
+    if (verbosity>2) printf("%sAllocate density maxima among the subfields.\n", spaces);
+    subFieldNumHighPoints = malloc(sizeof(int)        *numSubFields);
+    subFieldHighDensities = malloc(sizeof(double    *)*numSubFields);
+    subFieldHighLocations = malloc(sizeof(locusType *)*numSubFields);
+    memset(subFieldNumHighPoints, 0, sizeof(int)*numSubFields);
+
+    if (numHighPoints==0 || highPointLocations==NULL || highPointDensities==NULL){
+      for(sci=0;sci<numSubFields;sci++){
+        subFieldHighDensities[sci] = NULL;
+        subFieldHighLocations[sci] = NULL;
+      }
+
+    } else {
+      subFieldThisPoint = malloc(sizeof(int)*numInRandoms);
+      for(ppi=0;ppi<numHighPoints;ppi++){
+        if (verbosity>3) printf("%s  Density maximum %d\n", spaces, ppi);
+        for(di=0;di<DIM;di++)
+          location.x[di] = highPointLocations[ppi].x[di];
+
+        pointAllocated = 0;
+
+        /* Loop over all the subfields and stop when the one which contains the point is found.
+        */
+        sci = 0;
+        while (!pointAllocated && sci<numSubFields){
+          subFieldExcluded = 0;
+
+          /* Loop through the dimensions and, for each one, check to see if the respective coordinate of the point is outside the range for that subfield. If so, exit the dimensions loop, because the point can't be in the subfield: there is no point checking any more dimensions.
+          */ 
+          di = 0;
+          while (!subFieldExcluded && di<DIM){
+            if ((location.x[di]  < subFieldOrigins[sci][di])\
+            ||  (location.x[di] >= subFieldOrigins[sci][di] + subFieldLengths[sci][di]))
+              subFieldExcluded = 1;
+
+            di++;
+          }
+          if (!subFieldExcluded){
+            pointAllocated = 1;
+            subFieldNumHighPoints[sci]++;
+            subFieldThisPoint[ppi] = sci;
+          }
+          sci++;
+        }
+//**** complain if !pointAllocated - bug
+      }
+
+      for(sci=0;sci<numSubFields;sci++){
+        if (subFieldNumHighPoints[sci]>0){
+          subFieldHighDensities[sci] = malloc(sizeof(double   )*subFieldNumHighPoints[sci]);
+          subFieldHighLocations[sci] = malloc(sizeof(locusType)*subFieldNumHighPoints[sci]);
+        } else {
+          subFieldHighDensities[sci] = NULL;
+          subFieldHighLocations[sci] = NULL;
+        }
+      }
+
+      indices = malloc(sizeof(int)*numSubFields);
+      memset(indices, 0, sizeof(int)*numSubFields);
+      for(ppi=0;ppi<numHighPoints;ppi++){
+        sci = subFieldThisPoint[ppi];
+        subFieldHighDensities[sci][indices[sci]] = highPointDensities[ppi];
+        for(di=0;di<DIM;di++)
+          subFieldHighLocations[sci][indices[sci]].x[di] = highPointLocations[ppi].x[di];
+        indices[sci]++;
+      }
+      free(indices);
+      free(subFieldThisPoint);
+    }
+
+    /* Find the sum and max of the density values in each sub-cube, using the offset-and-scaled inRandLocations:
+    */
+    if (verbosity>2) printf("%sCalculate max and sum densitities.\n", spaces);
+    subFieldDensities    = malloc(sizeof(double *)*numSubFields);
+    subFieldMaxDensities = malloc(sizeof(double)  *numSubFields);
+    subFieldSumDensities = malloc(sizeof(double)  *numSubFields);
+    for(sci=0;sci<numSubFields;sci++){
+      subFieldDensities[sci] = malloc(sizeof(double)*numInRandoms);
+      subFieldSumDensities[sci] = 0.0;
+      for(ppi=0;ppi<numInRandoms;ppi++){
+        for(di=0;di<DIM;di++)
+          location.x[di] = inRandLocations[ppi].x[di]*subFieldLengths[sci][di] + subFieldOrigins[sci][di];
+        subFieldDensities[sci][ppi] = numberDensyFunc(location);
+        subFieldSumDensities[sci] += subFieldDensities[sci][ppi];
+      }
+
+      ppi = 0;
+      subFieldMaxDensities[sci] = subFieldDensities[sci][ppi];
+      for(ppi=1;ppi<numInRandoms;ppi++)
+        if (subFieldDensities[sci][ppi]>subFieldMaxDensities[sci])
+          subFieldMaxDensities[sci] = subFieldDensities[sci][ppi];
+
+      if(highPointDensities!=NULL){
+        for(ppi=0;ppi<numHighPoints;ppi++)
+          if (highPointDensities[ppi]>subFieldMaxDensities[sci])
+            subFieldMaxDensities[sci] = highPointDensities[ppi];
+      }
+    }
+
+    /* Estimate the integral of the density in each sub-cube:
+    */
+    if (verbosity>2) printf("%sEstimate density integrals.\n", spaces);
+    subFieldDensityIntegrals = malloc(sizeof(double)*numSubFields);
+    totalDensityIntegral = 0.0;
+    for(sci=0;sci<numSubFields;sci++){
+      subFieldDensityIntegrals[sci] = subFieldSumDensities[sci]\
+        * subFieldVolumes[sci] / (double)numInRandoms;
+      totalDensityIntegral += subFieldDensityIntegrals[sci];
+
+      if (verbosity>3) printf("%sSummed density for sub-field %d is %e.\n", spaces, sci, subFieldSumDensities[sci]);
+      if (verbosity>3) printf("%sIntegrated density for sub-field %d is %e.\n", spaces, sci, subFieldDensityIntegrals[sci]);
+    }
+
+//*** raise exception if totalDensityIntegral<=0
+
+    /* Calculate a desired number of points for each subcube. We'll only bother with cubes with non-zero densities.
+    */
+    if (verbosity>2) printf("%sCalculate desired number of points.\n", spaces);
+    subFieldDesNumPoints = malloc(sizeof(unsigned int)*numSubFields);
+    remainingDesNum = desiredNumPoints;
+    remainingDensy = totalDensityIntegral;
+    for(sci=0;sci<numSubFields;sci++){
+      /* Generate a random number from a binomial distribution for the desired number of points in the sub-cube:
+      */
+      probability = subFieldDensityIntegrals[sci]/remainingDensy;
+      if (probability>1.0) probability = 1.0;
+//*********** have a think what happens (or is supposed to happen) if this ==1.
+
+      if (probability>0){
+        subFieldDesNumPoints[sci] = gsl_ran_binomial(randGen, probability, remainingDesNum);
+        remainingDesNum -= subFieldDesNumPoints[sci];
+        remainingDensy -= subFieldDensityIntegrals[sci];
+      }else
+        subFieldDesNumPoints[sci] = 0;
+    }
+
+//*** raise exception if remainingDesNum>0
+
+    /* Now call the function for each valid subcube. Ignore subcubes with desiredNumPoints<=0.
+    */
+    localStartI = startI;
+    for(sci=0;sci<numSubFields;sci++){
+      if (verbosity>3) printf("%s%d points required for sub-field %d.\n", spaces, subFieldDesNumPoints[sci], sci);
+      if (subFieldDesNumPoints[sci]>0){
+        if (verbosity>2) printf("%sCall the function for the %dth sub-field.\n", spaces, sci);
+
+        randomsViaTree(levelI+1, numSubFields, subFieldOrigins[sci]\
+          , subFieldLengths[sci], subFieldVolumes[sci], subFieldDesNumPoints[sci]\
+          , localStartI, subFieldNumHighPoints[sci]\
+          , subFieldHighLocations[sci], subFieldHighDensities[sci], numInRandoms, inRandLocations, subFieldDensities[sci]\
+          , subFieldSumDensities[sci], subFieldMaxDensities[sci]\
+          , randGen, numberDensyFunc, monitorFunc, outRandLocations, outRandDensities, verbosity);
+
+        localStartI += subFieldDesNumPoints[sci];
+      }
+    }
+
+    /* Free up everything else mallocd in this block:
+    */
+    if (verbosity>2) printf("%sFree everything.\n", spaces);
+    free(subFieldDesNumPoints);
+    free(subFieldDensityIntegrals);
+    free(subFieldSumDensities);
+    free(subFieldMaxDensities);
+    for(sci=0;sci<numSubFields;sci++){
+      if (subFieldDensities[sci]!=NULL)
+        free(subFieldDensities[sci]);
+      if (subFieldHighDensities[sci]!=NULL)
+        free(subFieldHighDensities[sci]);
+      if (subFieldHighLocations[sci]!=NULL){
+        free(subFieldHighLocations[sci]);
+      }
+      if (subFieldOrigins[sci]!=NULL)
+        free(subFieldOrigins[sci]);
+      if (subFieldLengths[sci]!=NULL)
+        free(subFieldLengths[sci]);
+    }
+    free(subFieldDensities);
+    free(subFieldHighDensities);
+    free(subFieldHighLocations);
+    free(subFieldNumHighPoints);
+    free(subFieldOrigins);
+    free(subFieldLengths);
+    free(subFieldVolumes);
+    free(sideMaxPoints);
+    free(sideMidPoints);
+
+  } else { /* don't divide into sub-cubes, just generate the required points for this cube. */
+    if (verbosity>1) printf("%sNot subdividing.\n", spaces);
+    /* We already have a bunch of evenly-distributed randoms with associated density values. So first let's loop through these, accepting any that pass the density criterion; we'll exit the loop (and the function) if we get enough points before we are finished.
+    */
+    piOut = startI;
+    lastPiOut = startI + desiredNumPoints;
+    piIn = 0;
+    while(piIn<numInRandoms && piOut<lastPiOut){
+      acceptanceChance = inRandDensities[piIn]/maxDensity;
+      if (acceptanceChance>1.0) acceptanceChance = 1.0;
+      if (gsl_rng_uniform(randGen)>(1.0-acceptanceChance)){ // which should suffice to exclude acceptance of density<=0, because this will give (1-p)>=1; but gsl_rng_uniform is always <1.
+        for(di=0;di<DIM;di++){
+          outRandLocations[piOut].x[di] = fieldOrigin[di] + fieldDimensions[di]*inRandLocations[piIn].x[di];
+        }
+        outRandDensities[piOut] = inRandDensities[piIn];
+
+        piOut++;
+      }
+      piIn++;
+    }
+
+    timeOut = 0;
+    while (piOut<lastPiOut || timeOut){
+      /* If we entered this loop, it means our input random points were not sufficient to make up the desired number. Generate more until we have enough.
+      */
+      for(di=0;di<DIM;di++)
+        location.x[di] = fieldOrigin[di] + fieldDimensions[di]*gsl_rng_uniform(randGen);
+
+      density = numberDensyFunc(location);
+      acceptanceChance = density/maxDensity;
+      if (acceptanceChance>1.0) acceptanceChance = 1.0;
+      if (gsl_rng_uniform(randGen)>(1.0-acceptanceChance)){
+        for(di=0;di<DIM;di++)
+          outRandLocations[piOut].x[di] = location.x[di];
+        outRandDensities[piOut] = density;
+
+        piOut++;
+      }
+      //**** set timeOut.
+    }
+
+    if (verbosity>2) printf("%spiOut=%d, %d expected\n", spaces, piOut, lastPiOut);
+
+    if (monitorFunc!=NULL)
+      monitorFunc(outRandLocations, outRandDensities, desiredNumPoints, startI, fieldOrigin, fieldDimensions);
+
+  }
+  if (verbosity>0) printf("%sLeaving randomsViaTree, level %d\n\n", spaces, levelI);
+}
+
 void randomsViaRejection(inputPars *par, unsigned int desiredNumPoints, gsl_rng *randGen\
   , double (*numberDensyFunc)(locusType), locusType *outRandLocations, double *outRandDensities){
 

--- a/src/random_points.c
+++ b/src/random_points.c
@@ -1,0 +1,94 @@
+/*
+ *  random_points.c
+ *  This file is part of LIME, the versatile line modeling engine
+ *
+ *  Copyright (C) 2015 The LIME development team
+ *
+ */
+
+#include "lime.h"
+
+void randomsViaRejection(inputPars *par, unsigned int desiredNumPoints, gsl_rng *randGen\
+  , double (*numberDensyFunc)(locusType), locusType *outRandLocations, double *outRandDensities){
+
+  extern double densityNormalizer;
+  double lograd; // The logarithm of the model radius.
+  double logmin; // Logarithm of par->minScale.
+  double r,theta,phi,sinPhi,z,semiradius;
+  double uniformRandom, density, acceptanceChance;
+  int k,i,di;
+  int pointIsAccepted;
+  locusType location;
+
+  lograd=log10(par->radius);
+  logmin=log10(par->minScale);
+
+  /* Sample pIntensity number of points */
+  for(k=0;k<desiredNumPoints;k++){
+    uniformRandom=gsl_rng_uniform(randGen);
+    pointIsAccepted=0;
+    /* Pick a point and check if we like it or not */
+    do{
+      if(par->sampling==0){
+        r=pow(10,logmin+gsl_rng_uniform(randGen)*(lograd-logmin));
+        theta=2.*PI*gsl_rng_uniform(randGen);
+        phi=PI*gsl_rng_uniform(randGen);
+        sinPhi=sin(phi);
+        location.x[0]=r*cos(theta)*sinPhi;
+        location.x[1]=r*sin(theta)*sinPhi;
+        if(DIM==3) location.x[2]=r*cos(phi);
+      } else if(par->sampling==1){
+        location.x[0]=(2*gsl_rng_uniform(randGen)-1)*par->radius;
+        location.x[1]=(2*gsl_rng_uniform(randGen)-1)*par->radius;
+        if(DIM==3) location.x[2]=(2*gsl_rng_uniform(randGen)-1)*par->radius;
+      } else if(par->sampling==2){
+        r=pow(10,logmin+gsl_rng_uniform(randGen)*(lograd-logmin));
+        theta=2.*PI*gsl_rng_uniform(randGen);
+        if(DIM==3) {
+          z=2*gsl_rng_uniform(randGen)-1.;
+          semiradius=r*sqrt(1.-z*z);
+          z*=r;
+          location.x[2]=z;
+        } else {
+          semiradius=r;
+        }
+        location.x[0]=semiradius*cos(theta);
+        location.x[1]=semiradius*sin(theta);
+      } else {
+        if(!silent) bail_out("Don't know how to sample model");
+        exit(1);
+      }
+      density = numberDensyFunc(location);
+      if(density>0.0){
+        acceptanceChance = pow(density/densityNormalizer, DENSITY_POWER);
+        if (uniformRandom<acceptanceChance) pointIsAccepted=1;
+      }
+    } while(!pointIsAccepted);
+
+    for(di=0;di<DIM;di++)
+      outRandLocations[k].x[di]=location.x[di];
+    outRandDensities[k] = density;
+
+    if(!silent) progressbar((double) k/((double)desiredNumPoints-1), 4);
+  }
+}
+
+double densityFunc3D(locusType location){
+  extern double modelRadiusSquared;
+  double rSquared=0.0;
+  int i;
+  double vals[99],totalDensity=0.0; //**** define MAX_N_COLL_PARTNERS in lime.h and dimension vals to that rather than 99.
+  extern int numCollisionPartners;
+
+  for(i=0;i<DIM;i++)
+    rSquared += location.x[i]*location.x[i];
+
+  if(rSquared>=modelRadiusSquared)
+    return 0.0;
+
+  density(location.x[0],location.x[1],location.x[2],vals);//****** Unsafe to assume DIM==3 like this.
+  for (i=0;i<numCollisionPartners;i++) totalDensity += vals[i];
+  return totalDensity;
+}
+
+

--- a/src/random_points.c
+++ b/src/random_points.c
@@ -515,7 +515,7 @@ void randomsViaRejection(inputPars *par, unsigned int desiredNumPoints, gsl_rng 
 }
 
 double densityFunc3D(locusType location){
-  extern double modelRadiusSquared;
+  extern double modelRadiusSquared, minDensity;
   double rSquared=0.0;
   int i;
   double vals[99],totalDensity=0.0; //**** define MAX_N_COLL_PARTNERS in lime.h and dimension vals to that rather than 99.
@@ -529,7 +529,11 @@ double densityFunc3D(locusType location){
 
   density(location.x[0],location.x[1],location.x[2],vals);//****** Unsafe to assume DIM==3 like this.
   for (i=0;i<numCollisionPartners;i++) totalDensity += vals[i];
-  return totalDensity;
+
+  if(totalDensity<minDensity)
+    return minDensity;
+  else
+    return totalDensity;
 }
 
 


### PR DESCRIPTION
This is a new optional algorithm for generating grid points. The original algorithm is based on the rejection method, but this is slow when the (number) density function is highly peaked (i.e. when its maximum value is many times its average value). To compensate for this, the original algorithm flattens the user-input density function by raising it to a small positive power. An effect of this is that dense areas of the model are undersampled.

I ran this fairly extensive code addition/modification through valgrind to fix reported memory leaks etc. This addition seems to work ok in that it produces images broadly similar to the previous; it probably needs some more extensive testing though to investigate the effects of the new algorithm.