### PR TITLE
Small speed-ups and fixes to photon packet tracking

### DIFF
--- a/src/fastexp.c
+++ b/src/fastexp.c
@@ -12,6 +12,7 @@
 
 extern double EXP_TABLE_2D[128][10];
 extern double EXP_TABLE_3D[256][2][10];
+extern double INV_TABLE[FAST_EXP_MAX_TAYLOR];
 
 
 int factorial(const int n){
@@ -181,9 +182,10 @@ See description of the lookup algorithm in function calcFastExpRange().
       }
     }
   }
+  for (l=0;l<FAST_EXP_MAX_TAYLOR;l++) INV_TABLE[l]=1.0/(l+1.0);
 }
 
-inline double FastExp(const float negarg){
+double FastExp(const float negarg){
   /*
 See description of the lookup algorithm in function calcFastExpRange(). ****NOTE!**** Most numbers here are hard-wired for the sake of speed. If need be, they can be verified (or recalculated for different conditions) via calcTableEntries().
   */
@@ -216,7 +218,7 @@ This value should be calculated from 127+lowestExponent, where 127 is the offset
   if (l<0){ // do the Taylor approximation.
     result = 1.0;
     for (i=FAST_EXP_MAX_TAYLOR;i>0;i--){
-      result = 1.0 - negarg*result/(double)i;
+      result = 1.0 - negarg*INV_TABLE[i-1]*result;
     }
     return result;
 
@@ -232,4 +234,3 @@ This value should be calculated from 127+lowestExponent, where 127 is the offset
           EXP_TABLE_3D[j1][0][l]*
           EXP_TABLE_3D[j2][1][l]);
 }
-

--- a/src/lime.h
+++ b/src/lime.h
@@ -246,7 +246,7 @@ int	factorial(const int n);
 double	taylor(const int maxOrder, const float x);
 void	calcFastExpRange(const int maxTaylorOrder, const int maxNumBitsPerMantField, int *numMantissaFields, int *lowestExponent, int *numExponentsUsed);
 void	calcTableEntries(const int maxTaylorOrder, const int maxNumBitsPerMantField);
-inline double	FastExp(const float negarg);
+double FastExp(const float negarg);
 
 
 /* Curses functions */

--- a/src/main.c
+++ b/src/main.c
@@ -12,12 +12,14 @@
 #ifdef FASTEXP
 double EXP_TABLE_2D[128][10];
 double EXP_TABLE_3D[256][2][10];
+double INV_TABLE[FAST_EXP_MAX_TAYLOR];
 /* I've hard-wired the dimensions of these arrays, but it would be better perhaps to declare them as pointers, and calculate the dimensions with the help of the function call:
   calcFastExpRange(FAST_EXP_MAX_TAYLOR, FAST_EXP_NUM_BITS, &numMantissaFields, &lowestExponent, &numExponentsUsed)
 */
 #else
 double EXP_TABLE_2D[1][1]; // nominal definitions so the fastexp.c module will compile.
 double EXP_TABLE_3D[1][1][1];
+double INV_TABLE[1];
 #endif
 
 int main () {

--- a/src/photon.c
+++ b/src/photon.c
@@ -11,6 +11,7 @@
 
 int
 sortangles(double *inidir, int id, struct grid *g, const gsl_rng *ran) {
+#ifdef OLD_RT
   int i,n[2];
   double angle,exitdir[2];
 
@@ -45,6 +46,32 @@ sortangles(double *inidir, int id, struct grid *g, const gsl_rng *ran) {
     }
     return n[1];
   }
+#else
+  // the old method finds the edge with the lowest dir\cdot inidir,
+  // i.e. the edge closest to the direction opposite to the inidir
+  // this has been changed, because it makes things cleaner
+  // when, e.g., calculating projections
+
+  int i,n;
+  double cos_angle,exit_cos;
+  exit_cos=-1e30;
+  n=-1;
+
+  for(i=0;i<g[id].numNeigh;i++){
+    cos_angle=( inidir[0]*g[id].dir[i].xn[0]
+           +inidir[1]*g[id].dir[i].xn[1]
+           +inidir[2]*g[id].dir[i].xn[2]);
+    if(cos_angle>exit_cos){
+      exit_cos=cos_angle;
+      n=i;
+    }
+  }
+  if(n==-1){
+    if(!silent) bail_out("Photon propagation error");
+    exit(1);
+  }
+  return n;
+#endif
 }
 
 
@@ -168,7 +195,7 @@ void
 photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPars *par,blend *matrix, gridPointData *mp, double *halfFirstDs){
   int iphot,iline,jline,here,there,firststep,dir,np_per_line,ip_at_line,l;
   int *counta, *countb,nlinetot;
-  double deltav,segment,vblend,dtau,expDTau,jnu,alpha,ds,vfac[par->nSpecies],pt_theta,pt_z,semiradius;
+  double deltav,segment,vblend,dtau,expDTau,jnu,alpha,ds,ds_prev,vfac[par->nSpecies],pt_theta,pt_z,semiradius;
   double *tau,*expTau,vel[3],x[3], inidir[3];
   double remnantSnu;
 
@@ -186,7 +213,7 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
       tau[iline]=0.;
       expTau[iline]=1.;
     }
-    
+
     /* Initial velocity, direction and frequency offset  */		
     pt_theta=gsl_rng_uniform(ran)*2*PI;
     pt_z=2*gsl_rng_uniform(ran)-1;
@@ -194,7 +221,7 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
     inidir[0]=semiradius*cos(pt_theta);
     inidir[1]=semiradius*sin(pt_theta);
     inidir[2]=pt_z;
-    
+
     iter=(int) (gsl_rng_uniform(ran)*(double)N_RAN_PER_SEGMENT); // can have values in [0,1,..,N_RAN_PER_SEGMENT-1]
     ip_at_line=(int) iphot/g[id].numNeigh;
     segment=(N_RAN_PER_SEGMENT*(ip_at_line-np_per_line/2.)+iter)/(double)(np_per_line*N_RAN_PER_SEGMENT);
@@ -208,13 +235,21 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
     dir=sortangles(inidir,id,g,ran);
     here=g[id].id;
     there=g[here].neigh[dir]->id;
+#ifdef OLD_RT
     deltav=segment*4.3*g[id].dopb+veloproject(g[id].dir[dir].xn,vel);
-    
+#else
+    deltav=segment*4.3*g[id].dopb+veloproject(inidir,vel);
+#endif
     /* Photon propagation loop */
     do{
       if(firststep){
         firststep=0;				
-        ds=g[here].ds[dir]/2.;
+#ifdef OLD_RT
+        ds=0.5*g[here].ds[dir];
+#else
+	ds=0.5*g[here].ds[dir]*(inidir[0]*g[here].dir[dir].xn[0]+inidir[1]*g[here].dir[dir].xn[1]+inidir[2]*g[here].dir[dir].xn[2]);
+        ds_prev=ds;
+#endif
         halfFirstDs[iphot]=ds;
         for(l=0;l<par->nSpecies;l++){
           if(!par->doPregrid) velocityspline(g,here,dir,g[id].mol[l].binv,deltav,&vfac[l]);
@@ -223,7 +258,13 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
         }
         for(l=0;l<3;l++) x[l]=g[here].x[l]+(g[here].dir[dir].xn[l] * g[id].ds[dir]/2.);
       } else {
+#ifdef OLD_RT
         ds=g[here].ds[dir];
+#else
+	ds=ds_prev;
+	ds_prev=0.5*g[here].ds[dir]*(inidir[0]*g[here].dir[dir].xn[0]+inidir[1]*g[here].dir[dir].xn[1]+inidir[2]*g[here].dir[dir].xn[2]);
+        ds+=ds_prev;
+#endif
         for(l=0;l<3;l++) x[l]=g[here].x[l];
       }
       
@@ -281,11 +322,19 @@ photon(int id, struct grid *g, molData *m, int iter, const gsl_rng *ran,inputPar
         /* End of line blending part */
       }
       
+#ifdef OLD_RT
       dir=sortangles(inidir,there,g,ran);
       here=there;
       there=g[here].neigh[dir]->id;
     } while(!g[there].sink);
-    
+#else
+      if (!g[here].sink) {
+         dir=sortangles(inidir,there,g,ran);
+         here=there;
+         there=g[here].neigh[dir]->id;
+      }
+    } while(!g[here].sink);
+#endif
     /* Add cmb contribution */
     if(m[0].cmb[0]>0.){
       for(iline=0;iline<nlinetot;iline++){


### PR DESCRIPTION
Slightly faster FastExp Taylor approximation computation.

Fixes the step-length projection issue and the half-interval offset in segment calculation. Velocity projection turned out to be more difficult to fix, and it is not included in this pull request.