### PR TITLE
Fix for issue #86

### DIFF
--- a/src/molinit.c
+++ b/src/molinit.c
@@ -240,7 +240,7 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
     /* Calculate molecular density */
     for(id=0;id<par->ncell; id++){
       for(ispec=0;ispec<par->nSpecies;ispec++){
-        if(m[i].npart == 1 && count[0] == 1){
+        if(m[i].npart == 1 && (count[0] == 1 || count[0] == 2 || count[0] == 3)){
           g[id].nmol[ispec]=g[id].abun[ispec]*g[id].dens[0];
         } else if(m[i].npart == 2 && (count[0] == 2 || count[0] == 3) && (count[1] == 2 || count[1] == 3)){
           if(!flag){


### PR DESCRIPTION
The LIME code can not handle properly the situation when there is only one collision partner and it is not H2 (see issue #86 ). If the collison partner is para- or ortho-H2 the code will not compute molecular density. The pull request fixes this problem allowing for para- or ortho-H2 to be a single collison partner.