### PR TITLE
Fixes #104

### DIFF
--- a/src/lime.h
+++ b/src/lime.h
@@ -77,6 +77,15 @@
 #define FAST_EXP_MAX_TAYLOR	3
 #define FAST_EXP_NUM_BITS	8
 
+/* Collision partner ID numbers from LAMDA */
+#define CP_H2			1
+#define CP_p_H2			2
+#define CP_o_H2			3
+#define CP_e			4
+#define CP_H			5
+#define CP_He			6
+#define CP_Hplus		7
+
 
 /* input parameters */
 typedef struct {

--- a/src/molinit.c
+++ b/src/molinit.c
@@ -103,12 +103,13 @@ planckfunc(int iline, double temp, molData *m,int s){
 
 void
 molinit(molData *m, inputPars *par, struct grid *g,int i){
-  int id, ilev, iline, itrans, ispec, itemp, *ntemp, tnint=-1, idummy, ipart, *count,flag=0;
-  char *collpartname[] = {"H2","p-H2","o-H2","electrons","H","He","H+"}; /* definition from LAMDA */
+  int id, ilev, iline, itrans, ispec, itemp, *ntemp, tnint=-1, idummy, ipart, *collPartIDs,flag=0;
+  char *collpartnames[] = {"H2","p-H2","o-H2","electrons","H","He","H+"}; /* definition from LAMDA */
   double fac, uprate, downrate=0, dummy, amass;
   struct data { double *colld, *temp; } *part;
+  const int sizeI=200;
 
-  char string[200], specref[90], partstr[90];
+  char string[sizeI], specref[90], partstr[90];
   FILE *fp;
 
   if((fp=fopen(par->moldatfile[i], "r"))==NULL) {
@@ -117,13 +118,13 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
   }
 
   /* Read the header of the data file */
-  fgets(string, 80, fp);
+  fgets(string, sizeI, fp);
   fgets(specref, 90, fp);
-  fgets(string, 80, fp);
+  fgets(string, sizeI, fp);
   fscanf(fp, "%lf\n", &amass);
-  fgets(string, 80, fp);
+  fgets(string, sizeI, fp);
   fscanf(fp, "%d\n", &m[i].nlev);
-  fgets(string, 80, fp);
+  fgets(string, sizeI, fp);
 
   m[i].eterm=malloc(sizeof(double)*m[i].nlev);
   m[i].gstat=malloc(sizeof(double)*m[i].nlev);
@@ -131,13 +132,13 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
   /* Read the level energies and statistical weights */
   for(ilev=0;ilev<m[i].nlev;ilev++){
     fscanf(fp, "%d %lf %lf", &idummy, &m[i].eterm[ilev], &m[i].gstat[ilev]);
-    fgets(string, 80, fp);
+    fgets(string, sizeI, fp);
   }
 
   /* Read the number of transitions and allocate array space */
-  fgets(string, 80, fp);
+  fgets(string, sizeI, fp);
   fscanf(fp, "%d\n", &m[i].nline);
-  fgets(string, 80, fp);
+  fgets(string, sizeI, fp);
 
   m[i].lal     = malloc(sizeof(int)*m[i].nline);
   m[i].lau     = malloc(sizeof(int)*m[i].nline);
@@ -170,14 +171,14 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
 
   /* Collision rates below here */
   if(par->lte_only==0){
-    fgets(string, 80, fp);
+    fgets(string, sizeI, fp);
     fscanf(fp,"%d\n", &m[i].npart);
-    count=malloc(sizeof(*count)*m[i].npart);
+    collPartIDs=malloc(sizeof(*collPartIDs)*m[i].npart);
     /* collision partner sanity check */
 
     if(m[i].npart > par->collPart) flag=1;
     if(m[i].npart < par->collPart){
-      if(!silent) bail_out("Error: Too many density profiles defined");
+      if(!silent) bail_out("Too many density profiles defined");
       exit(1);
     }
 
@@ -187,14 +188,28 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
     part = malloc(sizeof(struct data) * m[i].npart);
 
     for(ipart=0;ipart<m[i].npart;ipart++){
-      fgets(string, 80, fp);
-      fscanf(fp,"%d\n", &count[ipart]);
-      fgets(string, 80, fp);
-      fgets(string, 80, fp);
+      fgets(string, sizeI, fp);
+      fscanf(fp,"%d\n", &collPartIDs[ipart]);
+
+      /* We want to test if the comment after the coll partner ID number is longer than the buffer size. To do this, we write a character - any character, as long as it is not \0 - to the last element of the buffer:
+      */
+      string[sizeof(string)-1] = 'x';
+      if(fgets(string, sizeI, fp)==NULL){
+        if(!silent) bail_out("Read of collision-partner comment line failed.");
+        exit(1);
+      } else{
+        if(string[sizeof(string)-1]=='\0' && string[sizeof(string)-2]!='\n'){
+          /* The presence now of a final \0 means the comment string was either just long enough for the buffer, or too long; the absence of \n in the 2nd-last place means it was too long.
+          */
+          if(!silent) bail_out("Collision-partner comment line is too long.");
+          exit(1);
+        }
+      }
+      fgets(string, sizeI, fp);
       fscanf(fp,"%d\n", &m[i].ntrans[ipart]);
-      fgets(string, 80, fp);
+      fgets(string, sizeI, fp);
       fscanf(fp,"%d\n", &ntemp[ipart]);
-      fgets(string, 80, fp);
+      fgets(string, sizeI, fp);
 
       part[ipart].temp=malloc(sizeof(double)*ntemp[ipart]);
 
@@ -208,7 +223,7 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
       }
 
       fscanf(fp,"\n");
-      fgets(string, 80, fp);
+      fgets(string, sizeI, fp);
 
       part[ipart].colld=malloc(sizeof(double)*m[i].ntrans[ipart]*ntemp[ipart]);
 
@@ -226,10 +241,10 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
     fclose(fp);
 
     /* Print out collision partner information */
-    strcpy(partstr, collpartname[count[0]-1]);
+    strcpy(partstr, collpartnames[collPartIDs[0]-1]);
     for(ipart=1;ipart<m[i].npart;ipart++){
       strcat( partstr, ", ");
-      strcat( partstr, collpartname[count[ipart]-1]);
+      strcat( partstr, collpartnames[collPartIDs[ipart]-1]);
     }
     if(!silent) {
       collpartmesg(specref, m[i].npart);
@@ -240,9 +255,12 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
     /* Calculate molecular density */
     for(id=0;id<par->ncell; id++){
       for(ispec=0;ispec<par->nSpecies;ispec++){
-        if(m[i].npart == 1 && (count[0] == 1 || count[0] == 2 || count[0] == 3)){
+        if(m[i].npart == 1\
+        && (collPartIDs[0]==CP_H2 || collPartIDs[0]==CP_p_H2 || collPartIDs[0]==CP_o_H2)){
           g[id].nmol[ispec]=g[id].abun[ispec]*g[id].dens[0];
-        } else if(m[i].npart == 2 && (count[0] == 2 || count[0] == 3) && (count[1] == 2 || count[1] == 3)){
+        } else if(m[i].npart == 2\
+        && (collPartIDs[0]==CP_p_H2 || collPartIDs[0]==CP_o_H2)\
+        && (collPartIDs[1]==CP_p_H2 || collPartIDs[1]==CP_o_H2)){
           if(!flag){
             g[id].nmol[ispec]=g[id].abun[ispec]*(g[id].dens[0]+g[id].dens[1]);
           } else {
@@ -291,7 +309,7 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
     }
     free(ntemp);
     free(part);
-    free(count);
+    free(collPartIDs);
   }
   /* End of collision rates */
 


### PR DESCRIPTION
In this commit I have done the following:
  . In lime.h:
    . Added macros for the LAMBDA identification integers for collision partners.
  . In the function molinit():
    . Changed the name 'count' (which must win some sort of an obscurity prize) to
'collPartIDs'.
    . Added an 's' to the name 'collpartname'.
    . Added a variable sizeI=200, dimensioned 'string' to this size, and read this many
characters into 'string' with each fget.
    . Added a test for buffer overflow in reading the comment line of the collision
partner ID, with an orderly exception for such cases.
    . Made use of the LAMBDA macros to make the choice for calculating nmol a bit more
clear.