### PR TITLE
Fixes #106

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -461,7 +461,7 @@ levelPops(molData *m, inputPars *par, struct grid *g, int *popsdone){
 
   for (i=0;i<par->nThreads;i++){
     threadRans[i] = gsl_rng_alloc(ranNumGenType);
-    gsl_rng_set(threadRans[i],(int)gsl_rng_uniform(ran)*1e6);
+    gsl_rng_set(threadRans[i],(int)(gsl_rng_uniform(ran)*1e6));
   }
 
   /* Read in all molecular data */


### PR DESCRIPTION
This was a 1-line fix to #106. Note however that it will change the detailed values of the output image, even with DTEST set in the Makefile.