### PR TITLE
Fix for #85

### DIFF
--- a/src/LTEsolution.c
+++ b/src/LTEsolution.c
@@ -28,7 +28,7 @@ void lteOnePoint(inputPars *par, molData *m, const int ispec, const double temp,
 
   sum = 0.0;
   for(ilev=0;ilev<m[ispec].nlev;ilev++){
-    pops[ilev] = m[ispec].gstat[ilev]*exp(-100*CLIGHT*HPLANCK*m[ispec].eterm[ilev]/(KBOLTZ*temp));
+    pops[ilev] = m[ispec].gstat[ilev]*exp(-HCKB*m[ispec].eterm[ilev]/temp);
     sum += pops[ilev];
   }
   for(ilev=0;ilev<m[ispec].nlev;ilev++)

--- a/src/LTEsolution.c
+++ b/src/LTEsolution.c
@@ -11,19 +11,12 @@
 
 void
 LTE(inputPars *par, struct grid *g, molData *m){
-  int id,ilev,ispec;
-  double z;
+  int id,ispec;
 
-  for(ispec=0;ispec<par->nSpecies;ispec++){
-    for(id=0;id<par->pIntensity;id++){
+  for(id=0;id<par->pIntensity;id++){
+    for(ispec=0;ispec<par->nSpecies;ispec++){
       g[id].nmol[ispec]=g[id].abun[ispec]*g[id].dens[0];
-      z=0;
-      for(ilev=0;ilev<m[ispec].nlev;ilev++){
-        z+=m[ispec].gstat[ilev]*exp(-100*CLIGHT*HPLANCK*m[ispec].eterm[ilev]/(KBOLTZ*g[id].t[0]));
-      }
-      for(ilev=0;ilev<m[ispec].nlev;ilev++){
-        g[id].mol[ispec].pops[ilev]=m[ispec].gstat[ilev]*exp(-100*CLIGHT*HPLANCK*m[ispec].eterm[ilev]/(KBOLTZ*g[id].t[0]))/z;
-      }
+      lteOnePoint(par, m, ispec, g[id].t[0], g[id].mol[ispec].pops);
     }
   }
   if(par->outputfile) popsout(par,g,m);

--- a/src/LTEsolution.c
+++ b/src/LTEsolution.c
@@ -29,3 +29,16 @@ LTE(inputPars *par, struct grid *g, molData *m){
   if(par->outputfile) popsout(par,g,m);
 }
 
+void lteOnePoint(inputPars *par, molData *m, const int ispec, const double temp, double *pops){
+  int ilev;
+  double sum;
+
+  sum = 0.0;
+  for(ilev=0;ilev<m[ispec].nlev;ilev++){
+    pops[ilev] = m[ispec].gstat[ilev]*exp(-100*CLIGHT*HPLANCK*m[ispec].eterm[ilev]/(KBOLTZ*temp));
+    sum += pops[ilev];
+  }
+  for(ilev=0;ilev<m[ispec].nlev;ilev++)
+    pops[ilev] /= sum;
+}
+

--- a/src/aux.c
+++ b/src/aux.c
@@ -451,6 +451,7 @@ levelPops(molData *m, inputPars *par, struct grid *g, int *popsdone){
   blend *matrix;
   struct statistics { double *pop, *ave, *sigma; } *stat;
   const gsl_rng_type *ranNumGenType = gsl_rng_ranlxs2;
+  _Bool luWarningGiven=0;
 
   stat=malloc(sizeof(struct statistics)*par->pIntensity);
 
@@ -546,7 +547,8 @@ levelPops(molData *m, inputPars *par, struct grid *g, int *popsdone){
           }
           if(g[id].dens[0] > 0 && g[id].t[0] > 0){
             photon(id,g,m,0,threadRans[threadI],par,matrix,mp,halfFirstDs);
-            for(ispec=0;ispec<par->nSpecies;ispec++) stateq(id,g,m,ispec,par,mp,halfFirstDs);
+            for(ispec=0;ispec<par->nSpecies;ispec++)
+              stateq(id,g,m,ispec,par,mp,halfFirstDs,&luWarningGiven);
           }
           if (threadI == 0){ // i.e., is master thread
             if(!silent) warning("");

--- a/src/aux.c
+++ b/src/aux.c
@@ -344,6 +344,25 @@ invSqrt(float x){
   return x;
 }
 
+void checkGridDensities(inputPars *par, struct grid *g){
+  int i;
+  static _Bool warningAlreadyIssued=0;
+  char errStr[80];
+
+  if(!silent){ /* Warn if any densities too low. */
+    i = 0;
+    while(i<par->pIntensity && !warningAlreadyIssued){
+      if(g[i].dens[0]<TYPICAL_ISM_DENS){
+        warningAlreadyIssued = 1;
+        sprintf(errStr, "g[%d].dens[0] at %.1e is below typical values for the ISM (~%.1e).", i, g[i].dens[0], TYPICAL_ISM_DENS);
+        warning(errStr);
+        warning("This could give you convergence problems. NOTE: no further warnings will be issued.");
+      }
+      i++;
+    }
+  }
+}
+
 void
 continuumSetup(int im, image *img, molData *m, inputPars *par, struct grid *g){
   int id;

--- a/src/aux.c
+++ b/src/aux.c
@@ -461,7 +461,7 @@ levelPops(molData *m, inputPars *par, struct grid *g, int *popsdone){
 
   for (i=0;i<par->nThreads;i++){
     threadRans[i] = gsl_rng_alloc(ranNumGenType);
-    gsl_rng_set(threadRans[i],(int)gsl_rng_uniform(ran)*1e6);
+    gsl_rng_set(threadRans[i],(int)(gsl_rng_uniform(ran)*1e6));
   }
 
   /* Read in all molecular data */

--- a/src/grid.c
+++ b/src/grid.c
@@ -624,6 +624,8 @@ buildGrid(inputPars *par, struct grid *g){
     abundance(  g[i].x[0],g[i].x[1],g[i].x[2], g[i].abun);
   }
 
+  checkGridDensities(par, g);
+
   //	getArea(par,g, ran);
   //	getMass(par,g, ran);
   getVelosplines(par,g);

--- a/src/lime.h
+++ b/src/lime.h
@@ -60,6 +60,7 @@
 #define maxp		0.15
 #define OtoP		3.
 #define GRAV		6.67428e-11
+#define TYPICAL_ISM_DENS	1000.0
 
 /* Other constants */
 #define NITERATIONS 	16
@@ -189,6 +190,7 @@ void gasIIdust(double,double,double,double *);
 void   	binpopsout(inputPars *, struct grid *, molData *);
 void   	buildGrid(inputPars *, struct grid *);
 void    calcSourceFn(double dTau, const inputPars *par, double *remnantSnu, double *expDTau);
+void	checkGridDensities(inputPars*, struct grid*);
 void	continuumSetup(int, image *, molData *, inputPars *, struct grid *);
 void	distCalc(inputPars *, struct grid *);
 void	fit_d1fi(double, double, double*);
@@ -214,6 +216,7 @@ void	line_plane_intersect(struct grid *, double *, int , int *, double *, double
 void	lineBlend(molData *, inputPars *, blend **);
 void    lineCount(int,molData *,int **, int **, int *);
 void	LTE(inputPars *, struct grid *, molData *);
+void	lteOnePoint(inputPars*, molData*, const int, const double, double*);
 void   	molinit(molData *, inputPars *, struct grid *,int);
 void    openSocket(inputPars *par, int);
 void	qhull(inputPars *, struct grid *);

--- a/src/lime.h
+++ b/src/lime.h
@@ -236,7 +236,7 @@ void	sourceFunc(double *, double *, double, molData *,double,struct grid *,int,i
 void    sourceFunc_line(double *,double *,molData *, double, struct grid *, int, int,int);
 void    sourceFunc_cont(double *,double *, struct grid *, int, int,int);
 void    sourceFunc_pol(double *, double *, double, molData *, double, struct grid *, int, int, int, double);
-void   	stateq(int, struct grid *, molData *, int, inputPars *,gridPointData *,double *);
+void   	stateq(int, struct grid*, molData*, int, inputPars*, gridPointData*, double*, _Bool*);
 void	statistics(int, molData *, struct grid *, int *, double *, double *, int *);
 void    stokesangles(double, double, double, double, double *);
 void    traceray(rayData, int, int, inputPars *, struct grid *, molData *, image *, int, int *, int *, double);

--- a/src/predefgrid.c
+++ b/src/predefgrid.c
@@ -49,6 +49,8 @@ predefinedGrid(inputPars *par, struct grid *g){
 	if(!silent) progressbar((double) i/((double)par->pIntensity-1), 4);	
   }
 
+  checkGridDensities(par, g);
+
   for(i=par->pIntensity;i<par->ncell;i++){
     x=2*gsl_rng_uniform(ran)-1.;
     y=2*gsl_rng_uniform(ran)-1.;

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -194,6 +194,7 @@ raytrace(int im, inputPars *par, struct grid *g, molData *m, image *img){
   double size,minfreq,absDeltaFreq,totalNumPixelsMinus1=(double)(img[im].pxls*img[im].pxls-1);
   double cutoff;
   const gsl_rng_type *ranNumGenType = gsl_rng_ranlxs2;
+  gsl_error_handler_t *defaultErrorHandler=NULL;
 
   gsl_rng *ran = gsl_rng_alloc(ranNumGenType);	/* Random number generator */
 #ifdef TEST
@@ -246,6 +247,13 @@ raytrace(int im, inputPars *par, struct grid *g, molData *m, image *img){
     }
   }
 
+  defaultErrorHandler = gsl_set_error_handler_off();
+  /*
+The GSL documentation does not recommend leaving the error handler at the default within multi-threaded code.
+
+While this is off however, gsl_* calls will not exit if they encounter a problem. We may need to pay some attention to trapping their errors.
+  */
+
   nRaysDone=0;
   omp_set_dynamic(0);
   #pragma omp parallel private(px,aa,threadI) num_threads(par->nThreads)
@@ -286,6 +294,7 @@ raytrace(int im, inputPars *par, struct grid *g, molData *m, image *img){
     free(ray.intensity);
   } /* End of parallel block. */
 
+  gsl_set_error_handler(defaultErrorHandler);
   img[im].trans=tmptrans;
 
   free(counta);

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -20,7 +20,6 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
   int t,s,iter,status;
   double *opop,*oopop,*tempNewPop=NULL;
   double diff;
-  gsl_error_handler_t *defaultErrorHandler=NULL;
   char errStr[80];
 
   gsl_matrix *matrix = gsl_matrix_alloc(m[ispec].nlev+1, m[ispec].nlev+1);
@@ -44,9 +43,6 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
   gsl_vector_set(rhVec,m[ispec].nlev-1,1.);
   diff=1;
   iter=0;
-
-  defaultErrorHandler = gsl_set_error_handler_off();
-  /* While this is off, the gsl_matrix_* etc calls will not exit if they encounter a problem. However the usual problem they would have is out-of-range indices; the respective code is simple enough though that the likelihood of this sort of problem seems low. */
 
   while((diff>TOL && iter<MAXITER) || iter<5){
     getjbar(id,m,g,par,mp,halfFirstDs);
@@ -97,8 +93,6 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
     }
     iter++;
   }
-
-  gsl_set_error_handler(defaultErrorHandler);
 
   gsl_matrix_free(matrix);
   gsl_matrix_free(reduc);

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -16,21 +16,23 @@ void
 stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
   , gridPointData *mp, double *halfFirstDs, _Bool *luWarningGiven){
 
-  int t,s,iter;
-  double *opop, *oopop;
+  int t,s,iter,status;
+  double *opop,*oopop,*tempNewPop=NULL;
   double diff;
+  gsl_error_handler_t *defaultErrorHandler=NULL;
+  char errStr[80];
 
   gsl_matrix *matrix = gsl_matrix_alloc(m[ispec].nlev+1, m[ispec].nlev+1);
   gsl_matrix *reduc  = gsl_matrix_alloc(m[ispec].nlev, m[ispec].nlev);
   gsl_vector *newpop = gsl_vector_alloc(m[ispec].nlev);
-  gsl_vector *rhVec = gsl_vector_alloc(m[ispec].nlev);
+  gsl_vector *rhVec  = gsl_vector_alloc(m[ispec].nlev);
   gsl_matrix *svv    = gsl_matrix_alloc(m[ispec].nlev, m[ispec].nlev);
   gsl_vector *svs    = gsl_vector_alloc(m[ispec].nlev);
   gsl_vector *work   = gsl_vector_alloc(m[ispec].nlev);
   gsl_permutation *p = gsl_permutation_alloc (m[ispec].nlev);
 
-  opop	 = malloc(sizeof(*opop)*m[ispec].nlev);
-  oopop	 = malloc(sizeof(*oopop)*m[ispec].nlev);
+  opop	     = malloc(sizeof(*opop)      *m[ispec].nlev);
+  oopop	     = malloc(sizeof(*oopop)     *m[ispec].nlev);
 
   for(t=0;t<m[ispec].nlev;t++){
     opop[t]=0.;

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -13,7 +13,9 @@
 
 
 void
-stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par, gridPointData *mp, double *halfFirstDs){
+stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
+  , gridPointData *mp, double *halfFirstDs, _Bool *luWarningGiven){
+
   int t,s,iter;
   double *opop, *oopop;
   double diff;

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -23,7 +23,7 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
   gsl_matrix *matrix = gsl_matrix_alloc(m[ispec].nlev+1, m[ispec].nlev+1);
   gsl_matrix *reduc  = gsl_matrix_alloc(m[ispec].nlev, m[ispec].nlev);
   gsl_vector *newpop = gsl_vector_alloc(m[ispec].nlev);
-  gsl_vector *oldpop = gsl_vector_alloc(m[ispec].nlev);
+  gsl_vector *rhVec = gsl_vector_alloc(m[ispec].nlev);
   gsl_matrix *svv    = gsl_matrix_alloc(m[ispec].nlev, m[ispec].nlev);
   gsl_vector *svs    = gsl_vector_alloc(m[ispec].nlev);
   gsl_vector *work   = gsl_vector_alloc(m[ispec].nlev);
@@ -35,9 +35,9 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
   for(t=0;t<m[ispec].nlev;t++){
     opop[t]=0.;
     oopop[t]=0.;
-    gsl_vector_set(oldpop,t,0.);
+    gsl_vector_set(rhVec,t,0.);
   }
-  gsl_vector_set(oldpop,m[ispec].nlev-1,1.);
+  gsl_vector_set(rhVec,m[ispec].nlev-1,1.);
   diff=1;
   iter=0;
 
@@ -54,9 +54,9 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
     gsl_linalg_LU_decomp(reduc,p,&s);
     if(gsl_linalg_LU_det(reduc,s) == 0){
       gsl_linalg_SV_decomp(reduc,svv, svs, work);
-      gsl_linalg_SV_solve(reduc, svv, svs, oldpop, newpop);
+      gsl_linalg_SV_solve(reduc, svv, svs, rhVec, newpop);
       if(!silent) warning("Matrix is singular. Switching to SVD.");
-    } else gsl_linalg_LU_solve(reduc,p,oldpop,newpop);
+    } else gsl_linalg_LU_solve(reduc,p,rhVec,newpop);
 
     diff=0.;
     for(t=0;t<m[ispec].nlev;t++){
@@ -78,7 +78,7 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par\
   gsl_matrix_free(matrix);
   gsl_matrix_free(reduc);
   gsl_matrix_free(svv);
-  gsl_vector_free(oldpop);
+  gsl_vector_free(rhVec);
   gsl_vector_free(newpop);
   gsl_vector_free(svs);
   gsl_vector_free(work);


### PR DESCRIPTION
The changes here are as follows:

- Added a warning if the density is too low at any grid point.
- LTE is now broken into 2 parts: the new function calculates the LTE solution for a single grid point and species.
- In stateq():
  - The SVD alternative has been removed.
  - The test of determinant==0 of the LU-decomposed matrix as a way to determine if the matrix is singular has been replaced by a test of the returned status value of the GSL LU solver.
  - The GSL error handler has been turned off for the duration of the matrix solution iteration loop so that failure and exit can be avoided in favour of an alternative way to estimate the populations at failing grid points.
  - LTE solution has been implemented as this alternative.
  - A warning message has been introduced if the LU fails.