### PR TITLE
Allows easy integration of LIME into ARTIST

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -19,17 +19,6 @@ parseInput(inputPars *par, image **img, molData **m){
   double BB[3];
   double cosPhi,sinPhi,cosTheta,sinTheta,dummyVel[DIM];
 
-  /* Allocate moldata array */
-  if(par->nSpecies > 1) {
-    (*m)=malloc(sizeof(molData)*par->nSpecies);
-    for(ispec=0;ispec<par->nSpecies;ispec++)
-      m[ispec]->nlev=0;
-  }
-  else {
-    (*m)=malloc(sizeof(molData)*1);
-    m[0]->nlev=0;
-  }
-
   par->ncell=par->pIntensity+par->sinkPoints;
   par->radiusSqu=par->radius*par->radius;
   par->minScaleSqu=par->minScale*par->minScale;

--- a/src/aux.c
+++ b/src/aux.c
@@ -57,16 +57,6 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
   */
   par->taylorCutoff = pow(24.*DBL_EPSILON, 0.25);
 
-  if(par->dust != NULL){
-    if((fp=fopen(par->dust, "r"))==NULL){
-      if(!silent) bail_out("Error opening dust opacity data file!");
-      exit(1);
-    }
-    else  {
-      fclose(fp);
-    }
-  }
-
   /* Allocate pixel space and parse image information */
   for(i=0;i<par->nImages;i++){
     if((*img)[i].nchan == 0 && (*img)[i].velres<0 ){

--- a/src/aux.c
+++ b/src/aux.c
@@ -15,7 +15,6 @@
 
 void
 parseInput(inputPars *par, image **img, molData **m){
-  FILE *fp;
   int i,id, ispec;
   double BB[3];
   double cosPhi,sinPhi,cosTheta,sinTheta,dummyVel[DIM];

--- a/src/aux.c
+++ b/src/aux.c
@@ -3,7 +3,7 @@
  *  This file is part of LIME, the versatile line modeling engine
  *
  *  Copyright (C) 2006-2014 Christian Brinch
- *  Copyright (C) 2015 The LIME development team
+ *  Copyright (C) 2016 The LIME development team
  *
  */
 
@@ -16,87 +16,19 @@
 void
 parseInput(inputPars *par, image **img, molData **m){
   FILE *fp;
-  int i,id;
+  int i,id, ispec;
   double BB[3];
   double cosPhi,sinPhi,cosTheta,sinTheta;
 
-  /* Set default values */
-  par->dust  	    = NULL;
-  par->inputfile    = NULL;
-  par->outputfile   = NULL;
-  par->binoutputfile= NULL;
-  par->gridfile     = NULL;
-  par->pregrid      = NULL;
-  par->restart      = NULL;
-
-  par->tcmb = 2.728;
-  par->lte_only=0;
-  par->init_lte=0;
-  par->sampling=2;
-  par->blend=0;
-  par->antialias=1;
-  par->polarization=0;
-  par->pIntensity=0;
-  par->sinkPoints=0;
-  par->doPregrid=0;
-  par->nThreads=0;
-
-  /* Allocate space for output fits images */
-  (*img)=malloc(sizeof(image)*MAX_NSPECIES);
-  par->moldatfile=malloc(sizeof(char *) * MAX_NSPECIES);
-  for(id=0;id<MAX_NSPECIES;id++){
-    (*img)[id].filename=NULL;
-    par->moldatfile[id]=NULL;
+  /* Allocate moldata array */
+  if(par->nSpecies > 1) {
+    (*m)=malloc(sizeof(molData)*par->nSpecies);
+    for(ispec=0;ispec<par->nSpecies;ispec++)
+      m[ispec]->nlev=0;
   }
-  input(par, *img);
-  id=-1;
-  while((*img)[++id].filename!=NULL);
-  par->nImages=id;
-  if(par->nImages==0) {
-    if(!silent) bail_out("Error: no images defined");
-    exit(1);
-  }
-
-  *img=realloc(*img, sizeof(image)*par->nImages);
-
-  id=-1;
-  while(par->moldatfile[++id]!=NULL);
-  par->nSpecies=id;
-  if( par->nSpecies == 0 )
-    {
-      par->nSpecies = 1;
-      free(par->moldatfile);
-      par->moldatfile = NULL;
-    }
-  else
-    {
-      par->moldatfile=realloc(par->moldatfile, sizeof(char *)*par->nSpecies);
-      /* Check if files exists */
-      for(id=0;id<par->nSpecies;id++){
-        if((fp=fopen(par->moldatfile[id], "r"))==NULL) {
-          openSocket(par, id);
-        }
-        else {
-          fclose(fp);
-        }
-      }
-    }
-
-
-  /* Set defaults and read inputPars and img[] */
-  for(i=0;i<par->nImages;i++) {
-    (*img)[i].source_vel=0.0;
-    (*img)[i].phi=0.0;
-    (*img)[i].nchan=0;
-    (*img)[i].velres=-1.;
-    (*img)[i].trans=-1;
-    (*img)[i].freq=-1.;
-    (*img)[i].bandwidth=-1.;
-  }
-  input(par,*img);
-
-  if(par->nThreads == 0){ // Hmm. Really ought to have a separate boolean parameter.
-    par->nThreads = NTHREADS;
+  else {
+    (*m)=malloc(sizeof(molData)*1);
+    m[0]->nlev=0;
   }
 
   par->ncell=par->pIntensity+par->sinkPoints;
@@ -225,9 +157,9 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
 }
 
 void
-freeInput( inputPars *par, image* img, molData* mol )
+freeMoldata( inputPars *par, molData* mol )
 {
-  int i,id;
+  int i;
   if( mol!= 0 )
     {
       for( i=0; i<par->nSpecies; i++ )
@@ -294,21 +226,6 @@ freeInput( inputPars *par, image* img, molData* mol )
             }
         }
       free(mol);
-    }
-  for(i=0;i<par->nImages;i++){
-    for(id=0;id<(img[i].pxls*img[i].pxls);id++){
-      free( img[i].pixel[id].intense );
-      free( img[i].pixel[id].tau );
-    }
-    free(img[i].pixel);
-  }
-  if( img != NULL )
-    {
-      free(img);
-    }
-  if( par->moldatfile != NULL )
-    {
-      free(par->moldatfile);
     }
 }
 

--- a/src/lime.h
+++ b/src/lime.h
@@ -3,7 +3,7 @@
  *  This file is part of LIME, the versatile line modeling engine
  *
  *  Copyright (C) 2006-2014 Christian Brinch
- *  Copyright (C) 2015 The LIME development team
+ *  Copyright (C) 2016 The LIME development team
  *
  */
 
@@ -185,6 +185,7 @@ void magfield(double,double,double,double *);
 void gasIIdust(double,double,double,double *);
 
 /* More functions */
+void    run(inputPars *, image *);
 
 void   	binpopsout(inputPars *, struct grid *, molData *);
 void   	buildGrid(inputPars *, struct grid *);
@@ -196,7 +197,7 @@ void    fit_fi(double, double, double*);
 void    fit_rr(double, double, double*);
 void   	input(inputPars *, image *);
 float  	invSqrt(float);
-void    freeInput(inputPars *, image*, molData* m );
+void    freeMoldata(inputPars *, molData* m );
 void   	freeGrid(const inputPars * par, const molData* m, struct grid * g);
 void   	freePopulation(const inputPars * par, const molData* m, struct populations * pop);
 double 	gaussline(double, double);

--- a/src/lime.h
+++ b/src/lime.h
@@ -7,6 +7,9 @@
  *
  */
 
+#ifndef LIME_H
+#define LIME_H
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -267,5 +270,4 @@ void    collpartmesg(char *, int);
 void    collpartmesg2(char *, int);
 void    collpartmesg3(int, int);
 
-
-
+#endif  /* LIME_H */

--- a/src/lime.h
+++ b/src/lime.h
@@ -38,7 +38,6 @@
 #define omp_set_dynamic(int) 0
 #endif
 
-#define silent 0
 #define DIM 3
 #define VERSION	"1.5"
 #define DEFAULT_NTHREADS 1
@@ -173,7 +172,8 @@ typedef struct {
 
 typedef struct {double x,y, *intensity, *tau;} rayData;
 
-
+/* Some global variables */
+int silent;
 
 /* Some functions */
 void density(double,double,double,double *);

--- a/src/main.c
+++ b/src/main.c
@@ -209,6 +209,8 @@ int main () {
   inputPars	par;
   image		*img = NULL;
 
+  silent = 0;
+
   initParImg(&par, &img);
 
   run(&par, img);

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,14 @@
 
 #include "lime.h"
 
+
+/* Forward declaration of functions only used in this file */
+void initParImg(inputPars *par, image **img);
+void freeParImg(inputPars *par, image *img);
+int main ();
+
+
+
 #ifdef FASTEXP
 double EXP_TABLE_2D[128][10];
 double EXP_TABLE_3D[256][2][10];

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,8 @@
  *  Copyright (C) 2016 The LIME development team
  *
  */
+#include <locale.h>
+
 #include "lime.h"
 
 #ifdef FASTEXP
@@ -159,6 +161,9 @@ run(inputPars *par, image *img)
   int popsdone=0;
   molData*     m = NULL;
   struct grid* g = NULL;
+
+  /*Set locale to avoid trouble when reading files*/
+  setlocale(LC_ALL, "C");
 
   if(!silent) greetings();
   if(!silent) screenInfo();

--- a/src/main.c
+++ b/src/main.c
@@ -209,8 +209,8 @@ run(inputPars *par, image *img)
 int main () {
   /* Main program for stand-alone LIME */
 
-  inputPars	par;
-  image		*img = NULL;
+  inputPars par;
+  image	*img = NULL;
 
   silent = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -53,9 +53,7 @@ initParImg(inputPars *par, image **img)
   par->sinkPoints=0;
   par->doPregrid=0;
 
-  if(par->nThreads == 0){ // Hmm. Really ought to have a separate boolean parameter.
-    par->nThreads = NTHREADS;
-  }
+  par->nThreads = NTHREADS;
 
   /* Allocate space for output fits images */
   (*img)=malloc(sizeof(image)*MAX_NSPECIES);

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,9 @@
  *  This file is part of LIME, the versatile line modeling engine
  *
  *  Copyright (C) 2006-2014 Christian Brinch
- *  Copyright (C) 2015 The LIME development team
+ *  Copyright (C) 2016 The LIME development team
  *
  */
-
 #include "lime.h"
 
 #ifdef FASTEXP
@@ -20,14 +19,146 @@ double EXP_TABLE_2D[1][1]; // nominal definitions so the fastexp.c module will c
 double EXP_TABLE_3D[1][1][1];
 #endif
 
-int main () {
+void
+initParImg(inputPars *par, image **img)
+{
+  /* Initialize par with default values, allocate space for the
+     output fits images, initialize the images with default values,
+     and finally call the input routine from model.c to set both the
+     par and image values.
+  */
+
+  int i, id;
+  FILE *fp;
+
+  /* Set default values */
+  par->dust  	    = NULL;
+  par->inputfile    = NULL;
+  par->outputfile   = NULL;
+  par->binoutputfile= NULL;
+  par->gridfile     = NULL;
+  par->pregrid      = NULL;
+  par->restart      = NULL;
+
+  par->tcmb = 2.728;
+  par->lte_only=0;
+  par->init_lte=0;
+  par->sampling=2;
+  par->blend=0;
+  par->antialias=1;
+  par->polarization=0;
+  par->pIntensity=0;
+  par->sinkPoints=0;
+  par->doPregrid=0;
+
+  if(par->nThreads == 0){ // Hmm. Really ought to have a separate boolean parameter.
+    par->nThreads = NTHREADS;
+  }
+
+  /* Allocate space for output fits images */
+  (*img)=malloc(sizeof(image)*MAX_NSPECIES);
+  par->moldatfile=malloc(sizeof(char *) * MAX_NSPECIES);
+  for(id=0;id<MAX_NSPECIES;id++){
+    (*img)[id].filename=NULL;
+    par->moldatfile[id]=NULL;
+  }
+  input(par, *img);
+  id=-1;
+  while((*img)[++id].filename!=NULL);
+  par->nImages=id;
+  if(par->nImages==0) {
+    if(!silent) bail_out("Error: no images defined");
+    exit(1);
+  }
+
+  *img=realloc(*img, sizeof(image)*par->nImages);
+
+  id=-1;
+  while(par->moldatfile[++id]!=NULL);
+  par->nSpecies=id;
+  if( par->nSpecies == 0 )
+    {
+      par->nSpecies = 1;
+      free(par->moldatfile);
+      par->moldatfile = NULL;
+    }
+  else
+    {
+      par->moldatfile=realloc(par->moldatfile, sizeof(char *)*par->nSpecies);
+      /* Check if files exists */
+      for(id=0;id<par->nSpecies;id++){
+        if((fp=fopen(par->moldatfile[id], "r"))==NULL) {
+          openSocket(par, id);
+        }
+        else {
+          fclose(fp);
+        }
+      }
+    }
+
+  if(par->dust != NULL){
+    if((fp=fopen(par->dust, "r"))==NULL){
+      if(!silent) bail_out("Error opening dust opacity data file!");
+      exit(1);
+    }
+    else  {
+      fclose(fp);
+    }
+  }
+
+  /* Set defaults and read inputPars and img[] */
+  for(i=0;i<par->nImages;i++) {
+    (*img)[i].source_vel=0.0;
+    (*img)[i].phi=0.0;
+    (*img)[i].nchan=0;
+    (*img)[i].velres=-1.;
+    (*img)[i].trans=-1;
+    (*img)[i].freq=-1.;
+    (*img)[i].bandwidth=-1.;
+  }
+  input(par,*img);
+}
+
+
+void
+freeParImg(inputPars *par, image *img)
+{
+  /* Release memory allocated for the output fits images
+     and for par->moldatfile
+  */
+  int i, id;
+  for(i=0;i<par->nImages;i++){
+    for(id=0;id<(img[i].pxls*img[i].pxls);id++){
+      free( img[i].pixel[id].intense );
+      free( img[i].pixel[id].tau );
+    }
+    free(img[i].pixel);
+  }
+  if( img != NULL )
+    {
+      free(img);
+    }
+  if( par->moldatfile != NULL )
+    {
+      free(par->moldatfile);
+    }
+}
+
+
+void
+run(inputPars *par, image *img)
+{
+  /* Run LIME with par and the output fits files specified.
+
+     This routine may be used as an interface to LIME from external
+     programs. In this case, par and img must be specified by the
+     external program.
+  */
   int i;
   int initime=time(0);
   int popsdone=0;
   molData*     m = NULL;
-  inputPars    par;
   struct grid* g = NULL;
-  image*       img = NULL;
 
   if(!silent) greetings();
   if(!silent) screenInfo();
@@ -36,38 +167,53 @@ int main () {
   calcTableEntries(FAST_EXP_MAX_TAYLOR, FAST_EXP_NUM_BITS);
 #endif
 
-  parseInput(&par,&img,&m);
+  parseInput(par, &img, &m);
 
-  if(par.doPregrid)
+  if(par->doPregrid)
     {
-      gridAlloc(&par,&g);
-      predefinedGrid(&par,g);
+      gridAlloc(par,&g);
+      predefinedGrid(par,g);
     }
-  else if(par.restart)
+  else if(par->restart)
     {
-      popsin(&par,&g,&m,&popsdone);
+      popsin(par,&g,&m,&popsdone);
     }
   else
     {
-      gridAlloc(&par,&g);
-      buildGrid(&par,g);
+      gridAlloc(par,&g);
+      buildGrid(par,g);
     }
 
-  for(i=0;i<par.nImages;i++){
+  for(i=0;i<par->nImages;i++){
     if(img[i].doline==1 && popsdone==0) {
-      levelPops(m,&par,g,&popsdone);
+      levelPops(m,par,g,&popsdone);
     }
     if(img[i].doline==0) {
-      continuumSetup(i,img,m,&par,g);
+      continuumSetup(i,img,m,par,g);
     }
 
-    raytrace(i,&par,g,m,img);
-    writefits(i,&par,m,img);
+    raytrace(i,par,g,m,img);
+    writefits(i,par,m,img);
   }
 
   if(!silent) goodnight(initime,img[0].filename);
 
-  freeGrid( &par, m, g);
-  freeInput(&par, img, m);
+  freeGrid( par, m, g);
+  freeMoldata(par, m);
+}
+
+
+int main () {
+  /* Main program for stand-alone LIME */
+
+  inputPars	par;
+  image		*img = NULL;
+
+  initParImg(&par, &img);
+
+  run(&par, img);
+
+  freeParImg(&par, img);
+
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -84,7 +84,7 @@ initParImg(inputPars *par, image **img)
   id=-1;
   while(par->moldatfile[++id]!=NULL);
   par->nSpecies=id;
-  if( par->nSpecies == 0 )
+  if( par->nSpecies <= 0 )
     {
       par->nSpecies = 1;
       free(par->moldatfile);


### PR DESCRIPTION
One central element of ARTIST is a SWIG interface to LIME to allow calling LIME from Python. Since LIME is designed as a stand-alone program, integrating LIME into ARTIST so far requires changes in LIME's code, mainly in aux.c where the input parameters and images are allocated and initialized.

In this PR, the critical parts of `parseInput` and `freeInput` in aux.c are moved to the new functions `initParImg` and `freeParImg` in main.c. In addition, the `main` function is split into the functions `run` and `main` (both in main.c), where `run` can serve as an interface to LIME for external programs (such as ARTIST), and `main` is used for stand-alone LIME.

Besides this structural change, some minor changes are necessary for easy integration of LIME into ARTIST:
- Made `silent` a global variable instead of a global constant
- Added a standard `#ifndef #define` construct to lime.h to avoid problems with including it more than once
- Set locale to "C" explicitely to avoid problems when reading in files
- Removed if statement around `par->nthreads = NTHREADS`

As a result of these changes, LIME's code can remain unchanged when integrating it into ARTIST which will make integration of future LIME versions much easier than in the past.