### PR TITLE
On-the-fly interpolation of collision coeffs.

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -215,8 +215,8 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
       (*m)[i].freq = NULL;
       (*m)[i].beinstu = NULL;
       (*m)[i].beinstl = NULL;
-      (*m)[i].up = NULL;
       (*m)[i].down = NULL;
+      (*m)[i].ntemp = NULL;
       (*m)[i].eterm = NULL;
       (*m)[i].gstat = NULL;
       (*m)[i].cmb = NULL;
@@ -268,14 +268,6 @@ freeInput( inputPars *par, image* img, molData* mol )
             {
               free(mol[i].beinstl);
             }
-          if( mol[i].up != NULL )
-            {
-              free(mol[i].up);
-            }
-          if( mol[i].down != NULL )
-            {
-              free(mol[i].down);
-            }
           if( mol[i].eterm != NULL )
             {
               free(mol[i].eterm);
@@ -292,6 +284,14 @@ freeInput( inputPars *par, image* img, molData* mol )
             {
               free(mol[i].local_cmb);
             }
+
+          if( mol[i].down != NULL )
+            {
+              for (int j=0;j<mol[i].npart;j++) free(mol[i].down[j]);
+              free(mol[i].down);
+            }
+	 free(mol[i].ntemp);
+
         }
       free(mol);
     }

--- a/src/grid.c
+++ b/src/grid.c
@@ -67,20 +67,6 @@ freePopulation(const inputPars *par, const molData* m, struct populations* pop )
             }
           if( pop[j].partner != NULL )
             {
-              if( m != NULL )
-                {
-                  for(k=0; k<m[j].npart; k++)
-                    {
-                      if( pop[j].partner[k].up != NULL )
-                        {
-                          free(pop[j].partner[k].up);
-                        }
-                      if( pop[j].partner[k].down != NULL )
-                        {
-                          free(pop[j].partner[k].down);
-                        }
-                    }
-                }
               free( pop[j].partner );
             }
         }

--- a/src/lime.h
+++ b/src/lime.h
@@ -62,12 +62,12 @@
 #define GRAV		6.67428e-11
 
 /* Other constants */
-#define NITERATIONS 	16
+#define NITERATIONS 		16
 #define max_phot		10000		/* don't set this value higher unless you have enough memory. */
 #define ininphot		9
 #define minpop			1.e-6
-#define eps				1.0e-30
-#define TOL				1e-6
+#define eps			1.0e-30
+#define TOL			1e-6
 #define MAXITER			50
 #define goal			50
 #define fixset			1e-6
@@ -93,9 +93,10 @@ typedef struct {
 
 /* Molecular data: shared attributes */
 typedef struct {
-  int nlev,nline,*ntrans,npart;
+  int nlev,nline,*ntrans,*ntemp,npart;
   int *lal,*lau,*lcl,*lcu;
-  double *aeinst,*freq,*beinstu,*beinstl,*up,*down,*eterm,*gstat;
+  double *aeinst,*freq,*beinstu,*beinstl,*eterm,*gstat;
+  double **down;
   double norm,norminv,*cmb,*local_cmb;
 } molData;
 
@@ -115,7 +116,8 @@ typedef struct {
 } point;
 
 struct rates {
-  double *up, *down;
+  int t_binlow;
+  double interp_coeff;
 };
 
 

--- a/src/molinit.c
+++ b/src/molinit.c
@@ -268,10 +268,6 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
 
     for(id=0;id<par->ncell;id++){
       g[id].mol[i].partner=malloc(sizeof(struct rates)*m[i].npart);
-      for(ipart=0;ipart<m[i].npart;ipart++){
-        // g[id].mol[i].partner[ipart].up = malloc(sizeof(double)*m[i].ntrans[ipart]);
-        // g[id].mol[i].partner[ipart].down = malloc(sizeof(double)*m[i].ntrans[ipart]);
-      }
     }
 
     for(id=0;id<par->ncell;id++){
@@ -284,18 +280,16 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
               }
             }
             fac=(g[id].t[0]-part[ipart].temp[tnint])/(part[ipart].temp[tnint+1]-part[ipart].temp[tnint]);
-            // downrate=part[ipart].colld[itrans*ntemp[ipart]+tnint]+fac*(part[ipart].colld[itrans*ntemp[ipart]+tnint+1]-part[ipart].colld[itrans*ntemp[ipart]+tnint]);
             g[id].mol[i].partner[ipart].t_binlow = tnint;
             g[id].mol[i].partner[ipart].interp_coeff = fac;
-          } else {
-            // if(g[id].t[0]<=part[ipart].temp[0]) downrate=part[ipart].colld[itrans*ntemp[ipart]];
-            // if(g[id].t[0]>=part[ipart].temp[ntemp[ipart]-1]) downrate=part[ipart].colld[itrans*ntemp[ipart]+ntemp[ipart]-1];
-            if(g[id].t[0]<=part[ipart].temp[0]) {g[id].mol[i].partner[ipart].t_binlow=0; g[id].mol[i].partner[ipart].interp_coeff=0.0;}
-            if(g[id].t[0]>=part[ipart].temp[ntemp[ipart]-1]) {g[id].mol[i].partner[ipart].t_binlow=ntemp[ipart]-2; g[id].mol[i].partner[ipart].interp_coeff=1.0;}
-          }
-          // uprate=m[i].gstat[m[i].lcu[itrans]]/m[i].gstat[m[i].lcl[itrans]]*downrate*exp(-HCKB*(m[i].eterm[m[i].lcu[itrans]]-m[i].eterm[m[i].lcl[itrans]])/g[id].t[0]);
-          // g[id].mol[i].partner[ipart].up[itrans]=uprate;
-          // g[id].mol[i].partner[ipart].down[itrans]=downrate;
+
+	    } else if(g[id].t[0]<=part[ipart].temp[0]) {
+	      g[id].mol[i].partner[ipart].t_binlow=0;
+	      g[id].mol[i].partner[ipart].interp_coeff=0.0;
+	    } else {
+	      g[id].mol[i].partner[ipart].t_binlow=ntemp[ipart]-2;
+	      g[id].mol[i].partner[ipart].interp_coeff=1.0;
+	   }
         }
       }
     }

--- a/src/molinit.c
+++ b/src/molinit.c
@@ -168,11 +168,13 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
     g[id].mol[i].binv=1./g[id].mol[i].dopb;
   }
 
+
   /* Collision rates below here */
   if(par->lte_only==0){
     fgets(string, 80, fp);
     fscanf(fp,"%d\n", &m[i].npart);
     count=malloc(sizeof(*count)*m[i].npart);
+    m[i].down=malloc(sizeof(double*)*m[i].npart);
     /* collision partner sanity check */
 
     if(m[i].npart > par->collPart) flag=1;
@@ -181,7 +183,7 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
       exit(1);
     }
 
-
+    m[i].ntemp = malloc(sizeof(int)*m[i].npart);
     m[i].ntrans = malloc(sizeof(int)*m[i].npart);
     ntemp = malloc(sizeof(*ntemp)*m[i].npart);
     part = malloc(sizeof(struct data) * m[i].npart);
@@ -222,6 +224,14 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
         }
         fscanf(fp,"\n");
       }
+
+      m[i].ntemp[ipart] = ntemp[ipart];
+      m[i].down[ipart] = malloc(sizeof(double)*m[i].ntrans[ipart]*m[i].ntemp[ipart]);
+      for(itrans=0;itrans<m[i].ntrans[ipart];itrans++) {
+        for(itemp=0;itemp<m[i].ntemp[ipart];itemp++) {
+	  m[i].down[ipart][itrans*m[i].ntemp[ipart]+itemp] = part[ipart].colld[itrans*m[i].ntemp[ipart]+itemp];
+        }
+      }
     }
     fclose(fp);
 
@@ -259,8 +269,8 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
     for(id=0;id<par->ncell;id++){
       g[id].mol[i].partner=malloc(sizeof(struct rates)*m[i].npart);
       for(ipart=0;ipart<m[i].npart;ipart++){
-        g[id].mol[i].partner[ipart].up = malloc(sizeof(double)*m[i].ntrans[ipart]);
-        g[id].mol[i].partner[ipart].down = malloc(sizeof(double)*m[i].ntrans[ipart]);
+        // g[id].mol[i].partner[ipart].up = malloc(sizeof(double)*m[i].ntrans[ipart]);
+        // g[id].mol[i].partner[ipart].down = malloc(sizeof(double)*m[i].ntrans[ipart]);
       }
     }
 
@@ -274,14 +284,18 @@ molinit(molData *m, inputPars *par, struct grid *g,int i){
               }
             }
             fac=(g[id].t[0]-part[ipart].temp[tnint])/(part[ipart].temp[tnint+1]-part[ipart].temp[tnint]);
-            downrate=part[ipart].colld[itrans*ntemp[ipart]+tnint]+fac*(part[ipart].colld[itrans*ntemp[ipart]+tnint+1]-part[ipart].colld[itrans*ntemp[ipart]+tnint]);
+            // downrate=part[ipart].colld[itrans*ntemp[ipart]+tnint]+fac*(part[ipart].colld[itrans*ntemp[ipart]+tnint+1]-part[ipart].colld[itrans*ntemp[ipart]+tnint]);
+            g[id].mol[i].partner[ipart].t_binlow = tnint;
+            g[id].mol[i].partner[ipart].interp_coeff = fac;
           } else {
-            if(g[id].t[0]<=part[ipart].temp[0]) downrate=part[ipart].colld[itrans*ntemp[ipart]];
-            if(g[id].t[0]>=part[ipart].temp[ntemp[ipart]-1]) downrate=part[ipart].colld[itrans*ntemp[ipart]+ntemp[ipart]-1];
+            // if(g[id].t[0]<=part[ipart].temp[0]) downrate=part[ipart].colld[itrans*ntemp[ipart]];
+            // if(g[id].t[0]>=part[ipart].temp[ntemp[ipart]-1]) downrate=part[ipart].colld[itrans*ntemp[ipart]+ntemp[ipart]-1];
+            if(g[id].t[0]<=part[ipart].temp[0]) {g[id].mol[i].partner[ipart].t_binlow=0; g[id].mol[i].partner[ipart].interp_coeff=0.0;}
+            if(g[id].t[0]>=part[ipart].temp[ntemp[ipart]-1]) {g[id].mol[i].partner[ipart].t_binlow=ntemp[ipart]-2; g[id].mol[i].partner[ipart].interp_coeff=1.0;}
           }
-          uprate=m[i].gstat[m[i].lcu[itrans]]/m[i].gstat[m[i].lcl[itrans]]*downrate*exp(-HCKB*(m[i].eterm[m[i].lcu[itrans]]-m[i].eterm[m[i].lcl[itrans]])/g[id].t[0]);
-          g[id].mol[i].partner[ipart].up[itrans]=uprate;
-          g[id].mol[i].partner[ipart].down[itrans]=downrate;
+          // uprate=m[i].gstat[m[i].lcu[itrans]]/m[i].gstat[m[i].lcl[itrans]]*downrate*exp(-HCKB*(m[i].eterm[m[i].lcu[itrans]]-m[i].eterm[m[i].lcl[itrans]])/g[id].t[0]);
+          // g[id].mol[i].partner[ipart].up[itrans]=uprate;
+          // g[id].mol[i].partner[ipart].down[itrans]=downrate;
         }
       }
     }

--- a/src/popsin.c
+++ b/src/popsin.c
@@ -36,7 +36,6 @@ popsin(inputPars *par, struct grid **g, molData **m, int *popsdone){
   for(i=0;i<par->nSpecies;i++){
     (*m)[i].lcl = NULL;
     (*m)[i].lcu = NULL;
-    (*m)[i].up = NULL;
     (*m)[i].down = NULL;
     (*m)[i].eterm = NULL;
     (*m)[i].gstat = NULL;

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -124,9 +124,14 @@ getmatrix(int id, gsl_matrix *matrix, molData *m, struct grid *g, int ispec, gri
 
   /* Populate matrix with collisional transitions */
   for(ipart=0;ipart<m[ispec].npart;ipart++){
+    double *downrates = m[ispec].down[ipart];
     for(t=0;t<m[ispec].ntrans[ipart];t++){
-      gsl_matrix_set(partner[ipart].colli, m[ispec].lcu[t], m[ispec].lcl[t], g[id].mol[ispec].partner[ipart].down[t]);
-      gsl_matrix_set(partner[ipart].colli, m[ispec].lcl[t], m[ispec].lcu[t], g[id].mol[ispec].partner[ipart].up[t]);
+      int trans_offset = t*m[ispec].ntemp[ipart];
+      double down = downrates[trans_offset+g[id].mol[ispec].partner[ipart].t_binlow] + g[id].mol[ispec].partner[ipart].interp_coeff*(downrates[trans_offset+g[id].mol[ispec].partner[ipart].t_binlow+1] -
+        downrates[trans_offset+ g[id].mol[ispec].partner[ipart].t_binlow]);
+      double up = down*m[ispec].gstat[m[ispec].lcu[t]]/m[ispec].gstat[m[ispec].lcl[t]]*exp(-HCKB*(m[ispec].eterm[m[ispec].lcu[t]]-m[ispec].eterm[m[ispec].lcl[t]])/g[id].t[0]);
+      gsl_matrix_set(partner[ipart].colli, m[ispec].lcu[t], m[ispec].lcl[t], down);
+      gsl_matrix_set(partner[ipart].colli, m[ispec].lcl[t], m[ispec].lcu[t], up);
     }
 
     for(p=0;p<m[ispec].nlev;p++){

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -88,7 +88,7 @@ stateq(int id, struct grid *g, molData *m, int ispec, inputPars *par, gridPointD
 
 void
 getmatrix(int id, gsl_matrix *matrix, molData *m, struct grid *g, int ispec, gridPointData *mp){
-  int p,t,k,l,ipart;
+  int p,t,ti,k,l,li,ipart;
   struct getmatrix {
     double *ctot;
     gsl_matrix * colli;
@@ -113,25 +113,24 @@ getmatrix(int id, gsl_matrix *matrix, molData *m, struct grid *g, int ispec, gri
   }
 
   /* Populate matrix with radiative transitions */
-  for(t=0;t<m[ispec].nline;t++){
-    k=m[ispec].lau[t];
-    l=m[ispec].lal[t];
-    gsl_matrix_set(matrix, k, k, gsl_matrix_get(matrix, k, k)+m[ispec].beinstu[t]*mp[ispec].jbar[t]+m[ispec].aeinst[t]);
-    gsl_matrix_set(matrix, l, l, gsl_matrix_get(matrix, l, l)+m[ispec].beinstl[t]*mp[ispec].jbar[t]);
-    gsl_matrix_set(matrix, k, l, gsl_matrix_get(matrix, k, l)-m[ispec].beinstl[t]*mp[ispec].jbar[t]);
-    gsl_matrix_set(matrix, l, k, gsl_matrix_get(matrix, l, k)-m[ispec].beinstu[t]*mp[ispec].jbar[t]-m[ispec].aeinst[t]);
+  for(li=0;li<m[ispec].nline;li++){
+    k=m[ispec].lau[li];
+    l=m[ispec].lal[li];
+    gsl_matrix_set(matrix, k, k, gsl_matrix_get(matrix, k, k)+m[ispec].beinstu[li]*mp[ispec].jbar[li]+m[ispec].aeinst[li]);
+    gsl_matrix_set(matrix, l, l, gsl_matrix_get(matrix, l, l)+m[ispec].beinstl[li]*mp[ispec].jbar[li]);
+    gsl_matrix_set(matrix, k, l, gsl_matrix_get(matrix, k, l)-m[ispec].beinstl[li]*mp[ispec].jbar[li]);
+    gsl_matrix_set(matrix, l, k, gsl_matrix_get(matrix, l, k)-m[ispec].beinstu[li]*mp[ispec].jbar[li]-m[ispec].aeinst[li]);
   }
 
   /* Populate matrix with collisional transitions */
   for(ipart=0;ipart<m[ispec].npart;ipart++){
     double *downrates = m[ispec].down[ipart];
-    for(t=0;t<m[ispec].ntrans[ipart];t++){
-      int trans_offset = t*m[ispec].ntemp[ipart];
-      double down = downrates[trans_offset+g[id].mol[ispec].partner[ipart].t_binlow] + g[id].mol[ispec].partner[ipart].interp_coeff*(downrates[trans_offset+g[id].mol[ispec].partner[ipart].t_binlow+1] -
-        downrates[trans_offset+ g[id].mol[ispec].partner[ipart].t_binlow]);
-      double up = down*m[ispec].gstat[m[ispec].lcu[t]]/m[ispec].gstat[m[ispec].lcl[t]]*exp(-HCKB*(m[ispec].eterm[m[ispec].lcu[t]]-m[ispec].eterm[m[ispec].lcl[t]])/g[id].t[0]);
-      gsl_matrix_set(partner[ipart].colli, m[ispec].lcu[t], m[ispec].lcl[t], down);
-      gsl_matrix_set(partner[ipart].colli, m[ispec].lcl[t], m[ispec].lcu[t], up);
+    for(ti=0;ti<m[ispec].ntrans[ipart];ti++){
+      int coeff_index = ti*m[ispec].ntemp[ipart] + g[id].mol[ispec].partner[ipart].t_binlow;
+      double down = downrates[coeff_index] + g[id].mol[ispec].partner[ipart].interp_coeff*(downrates[coeff_index+1] - downrates[coeff_index]);
+      double up = down*m[ispec].gstat[m[ispec].lcu[ti]]/m[ispec].gstat[m[ispec].lcl[ti]]*exp(-HCKB*(m[ispec].eterm[m[ispec].lcu[ti]]-m[ispec].eterm[m[ispec].lcl[ti]])/g[id].t[0]);
+      gsl_matrix_set(partner[ipart].colli, m[ispec].lcu[ti], m[ispec].lcl[ti], down);
+      gsl_matrix_set(partner[ipart].colli, m[ispec].lcl[ti], m[ispec].lcu[ti], up);
     }
 
     for(p=0;p<m[ispec].nlev;p++){


### PR DESCRIPTION
Implementation of the on-the-fly interpolation of collisional
coefficients that was discussed in comments to issue #81. With the
default example/model.c memory saving is about 50% and there is no
effect on speed.