### PR TITLE
More generic interface to gridDensity().

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -17,7 +17,7 @@ TODO:
 
 void
 parseInput(inputPars inpar, configInfo *par, image **img, molData **m){
-  int i,id,ispec;
+  int i,id;
   double BB[3],normBSquared,dens[MAX_N_COLL_PART];
   double cosPhi,sinPhi,cosTheta,sinTheta,dummyVel[DIM];
   FILE *fp;
@@ -129,6 +129,8 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
 
   */
   par->taylorCutoff = pow(24.*DBL_EPSILON, 0.25);
+
+  par->numDims = DIM;
 
   /* Allocate pixel space and parse image information */
   for(i=0;i<par->nImages;i++){

--- a/src/defaults.c
+++ b/src/defaults.c
@@ -53,17 +53,21 @@ void __attribute__((weak))
       *gas2dust=100.;
     }
 
-void __attribute__((weak))
-    gridDensity(configInfo par, double x, double y, double z, double *fracDensity){
+double __attribute__((weak))
+    gridDensity(configInfo *par, double *r){
       /* The grid points within the model are chosen randomly via the rejection method with a probability distribution which the present function is intended to provide. The user may supply their own version of this within model.c; the default here implements the grid-point selection function used in LIME<=1.5.
       */
-      double val[99],totalDensity=0.0;
+      double val[99],totalDensity=0.0,rSquared=0.0,fracDensity=0.0;
       int i;
       static double maxTotalDensity=0.0;
 
+      rSquared = r[0]*r[0]+r[1]*r[1]+r[2]*r[2];
+      if(rSquared>=par->radiusSqu)
+        return 0.0;
+
       if(maxTotalDensity==0.0){
-        density(par.minScale,par.minScale,par.minScale,val);
-        for (i=0;i<par.numDensities;i++)
+        density(par->minScale,par->minScale,par->minScale,val);
+        for (i=0;i<par->numDensities;i++)
           maxTotalDensity += val[i];
 
         if (maxTotalDensity<=0.){
@@ -72,8 +76,10 @@ void __attribute__((weak))
         }
       }
 
-      density(x,y,z,val);
-      for (i=0;i<par.numDensities;i++) totalDensity += val[i];
-      *fracDensity = pow(totalDensity/maxTotalDensity,0.2);
+      density(r[0],r[1],r[2],val);
+      for (i=0;i<par->numDensities;i++) totalDensity += val[i];
+      fracDensity = pow(totalDensity/maxTotalDensity,0.2);
+
+      return fracDensity;
     }
 

--- a/src/frees.c
+++ b/src/frees.c
@@ -137,7 +137,7 @@ freePop2(const int numSpecies, struct pop2 *mol){
 void
 freePopulation(configInfo *par, molData *m, struct populations *pop ){
   if(pop != NULL){
-    int j,k;
+    int j;
     for(j=0; j<par->nSpecies; j++){
       free( pop[j].pops );
       free( pop[j].knu );

--- a/src/grid.c
+++ b/src/grid.c
@@ -145,7 +145,7 @@ void calcGridDustOpacity(configInfo *par, molData *md, struct grid *gp){
 void calcGridCollRates(configInfo *par, molData *md, struct grid *g){
   int i,id,ipart,itrans,itemp,tnint=-1;
   struct cpData part;
-  double fac, uprate, downrate=0.0;
+  double fac;
 
   for(i=0;i<par->nSpecies;i++){
     for(id=0;id<par->ncell;id++){
@@ -627,22 +627,23 @@ void
 buildGrid(configInfo *par, struct grid *g){
   double lograd;		/* The logarithm of the model radius		*/
   double logmin;	    /* Logarithm of par->minScale				*/
-  double r,theta,phi,sinPhi,x,y,z,semiradius;	/* Coordinates								*/
-  double temp;
+  double r,theta,phi,sinPhi,z,semiradius;	/* Coordinates								*/
+  double uniformRandom;
   int k=0,i,j;            /* counters									*/
-  int flag;
+  int pointIsAccepted;
   struct cell *dc=NULL; /* Not used at present. */
   unsigned long numCells;
+  double x[DIM];
   const int maxNumAttempts=1000;
   _Bool numRandomsThisPoint;
   int numSecondRandoms=0;
   char errStr[80];
 
-  gsl_rng *ran = gsl_rng_alloc(gsl_rng_ranlxs2);	/* Random number generator */
+  gsl_rng *randGen = gsl_rng_alloc(gsl_rng_ranlxs2);	/* Random number generator */
 #ifdef TEST
-  gsl_rng_set(ran,342971);
+  gsl_rng_set(randGen,342971);
 #else
-  gsl_rng_set(ran,time(0));
+  gsl_rng_set(randGen,time(0));
 #endif  
   
   lograd=log10(par->radius);
@@ -650,10 +651,10 @@ buildGrid(configInfo *par, struct grid *g){
 
   /* Sample pIntensity number of points */
   for(k=0;k<par->pIntensity;k++){
-    flag=0;
+    pointIsAccepted=0;
     numRandomsThisPoint=0;
     do{
-      temp=gsl_rng_uniform(ran);
+      uniformRandom=gsl_rng_uniform(randGen);
 
       if(numRandomsThisPoint==1)
         numSecondRandoms++;
@@ -661,51 +662,48 @@ buildGrid(configInfo *par, struct grid *g){
 
       /* Pick a point and check if we like it or not */
       j=0;
-      while(!flag && j<maxNumAttempts){
+      while(!pointIsAccepted && j<maxNumAttempts){
         if(par->sampling==0){
-          r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));
-          theta=2.*PI*gsl_rng_uniform(ran);
-          phi=PI*gsl_rng_uniform(ran);
+          r=pow(10,logmin+gsl_rng_uniform(randGen)*(lograd-logmin));
+          theta=2.*PI*gsl_rng_uniform(randGen);
+          phi=PI*gsl_rng_uniform(randGen);
           sinPhi=sin(phi);
-          x=r*cos(theta)*sinPhi;
-          y=r*sin(theta)*sinPhi;
-          if(DIM==3) z=r*cos(phi);
-          else z=0.;
+          x[0]=r*cos(theta)*sinPhi;
+          x[1]=r*sin(theta)*sinPhi;
+          if(DIM==3) x[2]=r*cos(phi);
         } else if(par->sampling==1){
-          x=(2*gsl_rng_uniform(ran)-1)*par->radius;
-          y=(2*gsl_rng_uniform(ran)-1)*par->radius;
-          if(DIM==3) z=(2*gsl_rng_uniform(ran)-1)*par->radius;
-          else z=0;
+          x[0]=(2*gsl_rng_uniform(randGen)-1)*par->radius;
+          x[1]=(2*gsl_rng_uniform(randGen)-1)*par->radius;
+          if(DIM==3) x[2]=(2*gsl_rng_uniform(randGen)-1)*par->radius;
         } else if(par->sampling==2){
-          r=pow(10,logmin+gsl_rng_uniform(ran)*(lograd-logmin));
-          theta=2.*PI*gsl_rng_uniform(ran);
+          r=pow(10,logmin+gsl_rng_uniform(randGen)*(lograd-logmin));
+          theta=2.*PI*gsl_rng_uniform(randGen);
           if(DIM==3) {
-            z=2*gsl_rng_uniform(ran)-1.;
+            z=2*gsl_rng_uniform(randGen)-1.;
             semiradius=r*sqrt(1.-z*z);
             z*=r;
+            x[2]=z;
           } else {
-            z=0.;
             semiradius=r;
           }
-          x=semiradius*cos(theta);
-          y=semiradius*sin(theta);
+          x[0]=semiradius*cos(theta);
+          x[1]=semiradius*sin(theta);
         } else {
           if(!silent) bail_out("Don't know how to sample model");
           exit(1);
         }
-        if((x*x+y*y+z*z)<par->radiusSqu) flag=pointEvaluation(par,temp,x,y,z);
+        pointIsAccepted = pointEvaluation(par, uniformRandom, x);
         j++;
       }
-    } while(!flag);
+    } while(!pointIsAccepted);
     /* Now pointEvaluation has decided that we like the point */
 
     /* Assign values to the k'th grid point */
     /* I don't think we actually need to do this here... */
     g[k].id=k;
-    g[k].x[0]=x;
-    g[k].x[1]=y;
-    if(DIM==3) g[k].x[2]=z;
-    else g[k].x[2]=0.;
+    g[k].x[0]=x[0];
+    g[k].x[1]=x[1];
+    if(DIM==3) g[k].x[2]=x[2];
 
     g[k].sink=0;
     /* This next step needs to be done, even though it looks stupid */
@@ -724,16 +722,22 @@ buildGrid(configInfo *par, struct grid *g){
 
   /* Add surface sink particles */
   for(i=0;i<par->sinkPoints;i++){
-    theta=gsl_rng_uniform(ran)*2*PI;
-    if(DIM==3) z=2*gsl_rng_uniform(ran)-1.;
-    else z=0.;
-    semiradius=sqrt(1.-z*z);
-    x=semiradius*cos(theta);
-    y=semiradius*sin(theta);;
+    theta=gsl_rng_uniform(randGen)*2*PI;
+
+    if(DIM==3) {
+      z=2*gsl_rng_uniform(randGen)-1.;
+      semiradius=sqrt(1.-z*z);
+      x[2]=z;
+    } else {
+      semiradius=1.0;
+    }
+
+    x[0]=semiradius*cos(theta);
+    x[1]=semiradius*sin(theta);;
     g[k].id=k;
-    g[k].x[0]=par->radius*x;
-    g[k].x[1]=par->radius*y;
-    g[k].x[2]=par->radius*z;
+    g[k].x[0]=par->radius*x[0];
+    g[k].x[1]=par->radius*x[1];
+    if(DIM==3) g[k].x[2]=par->radius*x[2];
     g[k].sink=1;
     g[k].abun[0]=0;
     g[k].dens[0]=1e-30;//************** what is the low but non zero value for?
@@ -775,13 +779,13 @@ buildGrid(configInfo *par, struct grid *g){
     }
   }
 
-  //	getArea(par,g, ran);
-  //	getMass(par,g, ran);
+  //	getArea(par,g, randGen);
+  //	getMass(par,g, randGen);
   getVelosplines(par,g);
   dumpGrid(par,g);
   free(dc);
 
-  gsl_rng_free(ran);
+  gsl_rng_free(randGen);
   if(!silent) done(5);
 }
 

--- a/src/lime.h
+++ b/src/lime.h
@@ -119,7 +119,7 @@ typedef struct {
   char *pregrid;
   char *restart;
   char *dust;
-  int sampling,lte_only,init_lte,antialias,polarization,nThreads;
+  int sampling,lte_only,init_lte,antialias,polarization,nThreads,numDims;
   char **moldatfile;
 } configInfo;
 
@@ -286,7 +286,7 @@ void doppler(double,double,double, double *);
 void velocity(double,double,double,double *);
 void magfield(double,double,double,double *);
 void gasIIdust(double,double,double,double *);
-void gridDensity(configInfo,double,double,double,double*);
+double gridDensity(configInfo*, double*);
 
 /* More functions */
 void	run(inputPars, image *);
@@ -354,7 +354,7 @@ void	openSocket(char*);
 void	parseInput(inputPars, configInfo*, image**, molData**);
 void	photon(int, struct grid*, molData*, int, const gsl_rng*, configInfo*, const int, struct blendInfo, gridPointData*, double*);
 double	planckfunc(int, double, molData *, int);
-int	pointEvaluation(configInfo*, double, double, double, double);
+int	pointEvaluation(configInfo*, const double, double*);
 void	popsin(configInfo *, struct grid **, molData **, int *);
 void	popsout(configInfo *, struct grid *, molData *);
 void	predefinedGrid(configInfo *, struct grid *);

--- a/src/main.c
+++ b/src/main.c
@@ -38,7 +38,6 @@ initParImg(inputPars *par, image **img)
   */
 
   int i,id,nImages;
-  FILE *fp;
 
   /* Set 'impossible' default values for mandatory parameters */
   par->radius    = 0;

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -101,7 +101,7 @@ For a given image pixel position, this function evaluates the intensity of the t
 Note that the algorithm employed here is similar to that employed in the function photon() which calculates the average radiant flux impinging on a grid cell: namely the notional photon is started at the side of the model near the observer and 'propagated' in the receding direction until it 'reaches' the far side. This is rather non-physical in conception but it makes the calculation easier.
   */
   const int stokesIi=0;
-  int ichan,stokesId,di,i,posn,nposn,polMolI,polLineI,iline,molI,lineI;
+  int ichan,stokesId,di,i,posn,nposn,polMolI,polLineI,molI,lineI;
   double xp,yp,zp,x[DIM],dx[DIM],dist2,ndist2,col,ds,snu_pol[3],dtau;
   double contJnu,contAlpha,jnu,alpha,lineRedShift,vThisChan,deltav,vfac=0.;
   double remnantSnu,expDTau,brightnessIncrement;
@@ -269,7 +269,7 @@ This version of traceray implements a new algorithm in which the population valu
   const int stokesIi=0;
   const int numFaces = DIM+1, nVertPerFace=3;
   int ichan,stokesId,di,status,lenChainPtrs,entryI,exitI,vi,vvi,ci;
-  int si, polMolI, polLineI, iline, molI, lineI;
+  int si, polMolI, polLineI, molI, lineI;
   double xp,yp,zp,x[DIM],dir[DIM],projVelRay,vel[DIM];
   double xCmpntsRay[nVertPerFace], ds, snu_pol[3], dtau, contJnu, contAlpha;
   double jnu, alpha, lineRedShift, vThisChan, deltav, vfac, remnantSnu, expDTau;
@@ -481,7 +481,7 @@ This function constructs an image cube by following sets of rays (at least 1 per
 
   double size,oneOnNumActiveRaysMinus1,imgCentreXPixels,imgCentreYPixels,minfreq,absDeltaFreq,x[2],sum,oneOnNumRays;//,oneOnTotalNumPixelsMinus1
   unsigned int totalNumImagePixels,ppi,numPixelsForInterp;
-  int gi,molI,lineI,ei,li,nlinetot,iline,tmptrans,ichan,numActiveRays,i,di,xi,yi,ri,c,id,ids[3],vi;
+  int gi,molI,lineI,ei,li,nlinetot,tmptrans,ichan,numActiveRays,i,di,xi,yi,ri,c,id,ids[3],vi;
   int *allLineMolIs,*allLineLineIs,cmbMolI,cmbLineI;
   rayData *rays;
   struct cell *dc=NULL;

--- a/src/weights.c
+++ b/src/weights.c
@@ -9,13 +9,12 @@
 
 #include "lime.h"
 
-int
-pointEvaluation(configInfo *par, double ran, double x, double y, double z){
+int pointEvaluation(configInfo *par, const double uniformRandom, double *r){
   double fracDensity;
 
-  gridDensity(*par, x, y, z, &fracDensity);
+  fracDensity = gridDensity(par, r);
 
-  if(ran < fracDensity) return 1;
+  if(uniformRandom < fracDensity) return 1;
   else return 0;
 }
 


### PR DESCRIPTION
Detailed changes are as follows.
 - Added element `numDims` to `configInfo`.
 - Changed the interface to `defaults.c:gridDensity()` as suggested in #155.
 - This changed interface propagated to `weights.c:pointEvaluation()`.
 - Test for the point being within the model sphere radius moved from `grid.c:buildGrid()` to `defaults.c:gridDensity()`.
 - Better variable names in `grid.c:buildGrid()`.
 - Removed most of the alternates for `DIM==3` in `grid.c:buildGrid()` because both `grid.x` and the new `x` are `[DIM]` in size anyway.
 - Removed a few unused variables.