### PR TITLE
Add collScale parameter for scaling collisonal rates

### DIFF
--- a/doc/usermanual.rst
+++ b/doc/usermanual.rst
@@ -477,6 +477,18 @@ If none of the three density-linked parameters is provided, LIME will attempt to
 
 .. code:: c
 
+    (double) par->collScale (optional)
+
+This parameter specifies an scaling factor used by LIME for the collisional rates
+read from the molecular data files defined in par->moldatfile. This is useful
+when considering collisional rates with a molecule for which there are no values
+available in the literature. All the collisional rates from the LAMDA database
+can be scaled by the factor of the ratio of molecular weights or test varying the
+scaling without having to modify the input data files.  The default value of
+one uses the collisional rates from the molecular data files.
+
+.. code:: c
+
     (integer) par->traceRayAlgorithm (optional)
 
 This parameter specifies the algorithm used by LIME to solve the radiative-transfer equations during ray-tracing. The default value of zero invokes the algorithm used in LIME-1.5 and previous; a value of 1 invokes a new algorithm which is much more time-consuming but which produces much smoother images, free from step-artifacts.

--- a/src/aux.c
+++ b/src/aux.c
@@ -90,6 +90,8 @@ parseInput(inputPars inpar, configInfo *par, image **img, molData **m){
   for(i=0;i<MAX_N_COLL_PART;i++) par->nMolWeights[i] = inpar.nMolWeights[i];
   par->dustWeights  = malloc(sizeof(double)*MAX_N_COLL_PART);
   for(i=0;i<MAX_N_COLL_PART;i++) par->dustWeights[i] = inpar.dustWeights[i];
+  par->collScale    =  malloc(sizeof(double)*MAX_N_COLL_PART);
+  for(i=0;i<MAX_N_COLL_PART;i++) par->collScale[i] = inpar.collScale[i];
 
   /* Calculate par->numDensities.
   */

--- a/src/frees.c
+++ b/src/frees.c
@@ -108,6 +108,7 @@ freeParImg(const int nImages, inputPars *par, image *img){
   free(par->collPartIds);
   free(par->nMolWeights);
   free(par->dustWeights);
+  free(par->collScale);
 }
 
 void freePopulation(const unsigned short numSpecies, struct populations *pop){

--- a/src/inpars.h
+++ b/src/inpars.h
@@ -12,7 +12,7 @@
 
 /* input parameters */
 typedef struct {
-  double radius,minScale,tcmb,*nMolWeights,*dustWeights;
+  double radius,minScale,tcmb,*nMolWeights,*dustWeights,*collScale;
   int sinkPoints,pIntensity,blend,*collPartIds,traceRayAlgorithm;
   char *outputfile,*binoutputfile;
 //  char *inputfile; unused at present.

--- a/src/lime.h
+++ b/src/lime.h
@@ -102,7 +102,7 @@
 
 
 typedef struct {
-  double radius,minScale,tcmb,*nMolWeights,*dustWeights;
+  double radius,minScale,tcmb,*nMolWeights,*dustWeights,*collScale;
   double radiusSqu,minScaleSqu,taylorCutoff;
   int sinkPoints,pIntensity,blend,*collPartIds,traceRayAlgorithm;
   int ncell,nImages,nSpecies,numDensities,doPregrid;

--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,8 @@ initParImg(inputPars *par, image **img)
   for(i=0;i<MAX_N_COLL_PART;i++) par->nMolWeights[i] = -1.0;
   par->dustWeights  = malloc(sizeof(double)*MAX_N_COLL_PART);
   for(i=0;i<MAX_N_COLL_PART;i++) par->dustWeights[i] = -1.0;
+  par->collScale = malloc(sizeof(double)*MAX_N_COLL_PART);
+  for(i=0;i<MAX_N_COLL_PART;i++) par->collScale[i] = 1.0;
 
   par->tcmb = 2.728;
   par->lte_only=0;
@@ -248,6 +250,7 @@ run(inputPars inpars, image *img)
   free(par.collPartIds);
   free(par.nMolWeights);
   free(par.dustWeights);
+  free(par.collScale);
 
   if(par.dust != NULL){
     free(kaptab);

--- a/src/molinit.c
+++ b/src/molinit.c
@@ -220,7 +220,7 @@ void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds, int *
             for(itemp=0;itemp<md[i].part[k].ntemp;itemp++){
               j = itrans*md[i].part[k].ntemp+itemp;
               fscanf(fp, "%lf", &md[i].part[k].down[j]);
-              md[i].part[k].down[j] /= 1.0e6;
+              md[i].part[k].down[j] *= par->collScale[k]*1.0e-6;
             }
             fscanf(fp,"\n");
           }


### PR DESCRIPTION
This is useful when considering collisional rates with a molecule for
which there are no values available in the literature. The collisional
rates from the LAMDA database can be scaled by the factor of the ratio
of molecular weights with the collision partner.
