### PR TITLE
Remove par argument from lteOnePoint

### DIFF
--- a/src/LTEsolution.c
+++ b/src/LTEsolution.c
@@ -16,13 +16,13 @@ LTE(configInfo *par, struct grid *g, molData *m){
   for(id=0;id<par->pIntensity;id++){
     for(ispec=0;ispec<par->nSpecies;ispec++){
       g[id].mol[ispec].nmol = g[id].abun[ispec]*g[id].dens[0];
-      lteOnePoint(par, m, ispec, g[id].t[0], g[id].mol[ispec].pops);
+      lteOnePoint(m, ispec, g[id].t[0], g[id].mol[ispec].pops);
     }
   }
   if(par->outputfile) popsout(par,g,m);
 }
 
-void lteOnePoint(configInfo *par, molData *m, const int ispec, const double temp, double *pops){
+void lteOnePoint(molData *m, const int ispec, const double temp, double *pops){
   int ilev;
   double sum;
 

--- a/src/lime.h
+++ b/src/lime.h
@@ -349,7 +349,7 @@ void	levelPops(molData *, configInfo *, struct grid *, int *);
 void	line_plane_intersect(struct grid *, double *, int , int *, double *, double *, double);
 void	lineBlend(molData*, configInfo*, struct blendInfo*);
 void	LTE(configInfo *, struct grid *, molData *);
-void	lteOnePoint(configInfo*, molData*, const int, const double, double*);
+void	lteOnePoint(molData*, const int, const double, double*);
 void	openSocket(char*);
 void	parseInput(inputPars, configInfo*, image**, molData**);
 void	photon(int, struct grid*, molData*, int, const gsl_rng*, configInfo*, const int, struct blendInfo, gridPointData*, double*);

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -73,7 +73,7 @@ stateq(int id, struct grid *g, molData *m, const int ispec, configInfo *par\
         warning(errStr);
         warning("Doing LSE for this point. NOTE that no further warnings will be issued.");
       }
-      lteOnePoint(par, m, ispec, g[id].t[0], tempNewPop);
+      lteOnePoint(m, ispec, g[id].t[0], tempNewPop);
       for(s=0;s<m[ispec].nlev;s++)
         gsl_vector_set(newpop,s,tempNewPop[s]);
     }


### PR DESCRIPTION
`par` is defined but it is not used in the function's body.