### PR TITLE
Add IR pumping read from an input file

### DIFF
--- a/doc/usermanual.rst
+++ b/doc/usermanual.rst
@@ -594,6 +594,17 @@ These last two parameters mostly replace the functionality of the older `par->ou
 
 .. _images:
 
+.. code:: c
+
+    (string) par->girdatfile[i] (optional)
+
+Path to the i’th data file containing the effective IR pumping rate
+coefficients that can be determined by the contribution of cascading
+rotational levels within vibration bands as in Bensch & Bergin 2004.
+This effect is relevant for cometary coma exposed to solar radiation.
+girdatfile is an array, so a different data file can be used for each radiating
+species.  If this parameter is not supplied the effect will be ignored.
+
 Images
 ~~~~~~
 
@@ -1314,6 +1325,7 @@ Appendix: Bibliography
 ----------------------
 
 -  Ade et al., A&A 576, A105 (2015)
+-  Bensch & Bergin, ApJ, 615, 531, 2004
 -  Brinch & Hogerheijde, A&A, 523, A25, 2010; see also
    http://www.nbi.dk/~brinch/lime.php
 -  Hogerheijde & van der Tak, A&A, 362,697, 2000

--- a/src/aux.c
+++ b/src/aux.c
@@ -192,8 +192,11 @@ The parameters visible to the user have now been strictly confined to members of
 
   } else {
     par->moldatfile=malloc(sizeof(char *)*par->nSpecies);
-    for(id=0;id<par->nSpecies;id++)
+    par->girdatfile=malloc(sizeof(char *)*par->nSpecies);
+    for(id=0;id<par->nSpecies;id++){
       copyInparStr(inpar.moldatfile[id], &(par->moldatfile[id]));
+      copyInparStr(inpar.girdatfile[id], &(par->girdatfile[id]));
+    }
 
     /* Check if files exist. */
     for(id=0;id<par->nSpecies;id++){
@@ -631,6 +634,7 @@ Eventually I hope readOrBuildGrid() will be unilaterally called within LIME; if 
       (*md)[i].lal = NULL;
       (*md)[i].lau = NULL;
       (*md)[i].aeinst = NULL;
+      (*md)[i].gir = NULL;
       (*md)[i].freq = NULL;
       (*md)[i].beinstu = NULL;
       (*md)[i].beinstl = NULL;

--- a/src/aux.c
+++ b/src/aux.c
@@ -107,7 +107,7 @@ parseInput(const inputPars inpar, image *inimg, const int nImages, configInfo *p
 The parameters visible to the user have now been strictly confined to members of the structs 'inputPars' and 'image', both of which are defined in inpars.h. There are however further internally-set values which is is convenient to bundle together with the user-set ones. At present we have a fairly clunky arrangement in which the user-set values are copied member-by-member from the user-dedicated structs to the generic internal structs 'configInfo' and 'imageInfo'. This is done in the present function, along with some checks and other initialization.
   */
 
-  int i,j,id,status=0;
+  int i,j,id,status=0,numGirDatFiles;
   double BB[3],normBSquared,dens[MAX_N_COLL_PART],r[DIM];
   double dummyVel[DIM];
   FILE *fp;
@@ -185,6 +185,21 @@ The parameters visible to the user have now been strictly confined to members of
   while(par->nSpecies<MAX_NSPECIES && inpar.moldatfile[par->nSpecies]!=NULL && strlen(inpar.moldatfile[par->nSpecies])>0)
     par->nSpecies++;
 
+  numGirDatFiles=0;
+  while(numGirDatFiles<MAX_NSPECIES && inpar.girdatfile[numGirDatFiles]!=NULL && strlen(inpar.girdatfile[numGirDatFiles])>0)
+    numGirDatFiles++;
+
+  if(numGirDatFiles<=0)
+    par->girdatfile = NULL;
+  else if(numGirDatFiles!=par->nSpecies){
+    if(!silent) bail_out("Number of girdatfiles different from number of species.");
+  }else{
+    par->girdatfile=malloc(sizeof(char *)*par->nSpecies);
+    for(id=0;id<par->nSpecies;id++){
+      copyInparStr(inpar.girdatfile[id], &(par->girdatfile[id]));
+    }
+  }
+
   /* Copy over the moldatfiles.
   */
   if(par->nSpecies <= 0){
@@ -192,10 +207,8 @@ The parameters visible to the user have now been strictly confined to members of
 
   } else {
     par->moldatfile=malloc(sizeof(char *)*par->nSpecies);
-    par->girdatfile=malloc(sizeof(char *)*par->nSpecies);
     for(id=0;id<par->nSpecies;id++){
       copyInparStr(inpar.moldatfile[id], &(par->moldatfile[id]));
-      copyInparStr(inpar.girdatfile[id], &(par->girdatfile[id]));
     }
 
     /* Check if files exist. */

--- a/src/frees.c
+++ b/src/frees.c
@@ -33,6 +33,11 @@ freeConfigInfo(configInfo par){
       free(par.moldatfile[i]);
     free(par.moldatfile);
   }
+  if(par.girdatfile!= NULL){
+    for(i=0;i<par.nSpecies;i++)
+      free(par.girdatfile[i]);
+    free(par.girdatfile);
+  }
 
   free(par.gridOutFiles);
   free(par.gridDensMaxValues);
@@ -45,6 +50,7 @@ freeInputPars(inputPars par){
   free(par.nMolWeights);
   free(par.dustWeights);
   free(par.moldatfile);
+  free(par.girdatfile);
   free(par.collPartNames);
   free(par.gridOutFiles);
   free(par.gridDensMaxValues);
@@ -118,6 +124,7 @@ freeMolData(const int nSpecies, molData *mol){
       free(mol[i].lal);
       free(mol[i].lau);
       free(mol[i].aeinst);
+      free(mol[i].gir);
       free(mol[i].freq);
       free(mol[i].beinstu);
       free(mol[i].beinstl);

--- a/src/inpars.h
+++ b/src/inpars.h
@@ -16,6 +16,7 @@ typedef struct {
   double (*gridDensMaxLoc)[DIM],*gridDensMaxValues,*collPartMolWeights;
   int sinkPoints,pIntensity,blend,*collPartIds,traceRayAlgorithm,samplingAlgorithm;
   int sampling,lte_only,init_lte,antialias,polarization,nThreads;
+  char **girdatfile;
   int nSolveIters;
   char *outputfile,*binoutputfile,*gridfile,*pregrid,*restart,*dust;
   char *gridInFile,**gridOutFiles;

--- a/src/lime.h
+++ b/src/lime.h
@@ -144,7 +144,7 @@ typedef struct {
   int dataFlags,nSolveIters;
   char *outputfile,*binoutputfile,*gridfile,*pregrid,*restart,*dust;
   char *gridInFile,**gridOutFiles;
-  char **moldatfile,**collPartNames;
+  char **girdatfile,**moldatfile,**collPartNames;
   _Bool writeGridAtStage[NUM_GRID_STAGES],resetRNG,doInterpolateVels,useAbun;
 } configInfo;
 
@@ -158,7 +158,7 @@ struct cpData {
 typedef struct {
   int nlev,nline,npart;
   int *lal,*lau;
-  double *aeinst,*freq,*beinstu,*beinstl,*eterm,*gstat;
+  double *aeinst,*freq,*beinstu,*beinstl,*eterm,*gstat,*gir;
   double *cmb,amass;
   struct cpData *part;
   char molName[80];

--- a/src/main.c
+++ b/src/main.c
@@ -96,8 +96,10 @@ initParImg(inputPars *par, image **img)
 
   /* Allocate initial space for molecular data file names */
   par->moldatfile=malloc(sizeof(char *)*MAX_NSPECIES);
+  par->girdatfile=malloc(sizeof(char *)*MAX_NSPECIES);
   for(id=0;id<MAX_NSPECIES;id++){
     par->moldatfile[id]=NULL;
+    par->girdatfile[id]=NULL;
   }
 
   /* Allocate initial space for (non-LAMDA) collision partner names */

--- a/src/molinit.c
+++ b/src/molinit.c
@@ -60,7 +60,7 @@ checkFirstLineMolDat(FILE *fp, char *moldatfile){
 void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds, int *numUniqueCollPartsFound){
   /* NOTE! allUniqueCollPartIds is malloc'd in the present function, but not freed. The calling program must free it elsewhere.
   */
-  int i,j,k,ilev,jlev,idummy,iline,numPartsAcceptedThisMol,ipart,collPartId,itemp,itrans;
+  int i,j,k,ilev,idummy,iline,numPartsAcceptedThisMol,ipart,collPartId,itemp,itrans;
   double dummy;
   _Bool cpWasFoundInUserList,previousCpFound;
   const int sizeI=200;
@@ -105,7 +105,6 @@ void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds, int *
     md[i].lal     = malloc(sizeof(int)   *md[i].nline);
     md[i].lau     = malloc(sizeof(int)   *md[i].nline);
     md[i].aeinst  = malloc(sizeof(double)*md[i].nline);
-    md[i].gir     = malloc(sizeof(double)*md[i].nlev*md[i].nlev);
     md[i].freq    = malloc(sizeof(double)*md[i].nline);
     md[i].beinstu = malloc(sizeof(double)*md[i].nline);
     md[i].beinstl = malloc(sizeof(double)*md[i].nline);
@@ -248,20 +247,6 @@ void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds, int *
     }
 
     fclose(fp);
-
-    /* Read the pumping rate coefficients onto gir array */
-    for(ilev=0;ilev<md[i].nlev;ilev++){
-      for(jlev=0;jlev<md[i].nlev;jlev++){
-        md[i].gir[ilev*md[i].nlev+jlev] = 0.;
-      }
-    }
-    if((fp=fopen(par->girdatfile[i], "r")) != NULL){
-      while (fscanf(fp, "%d %d %lf", &ilev, &jlev, &dummy) != EOF) {
-        md[i].gir[(ilev-1)*md[i].nlev+jlev-1] = dummy;
-      }
-      fclose(fp);
-    }
-
   } /* end loop over molecule index i */
 
   if((*numUniqueCollPartsFound)<=0){
@@ -307,6 +292,28 @@ void calcMolCMBs(configInfo *par, molData *md){
     }
   }
 }
+/*....................................................................*/
+void setUpGir(configInfo *par, molData *md){
+  int i,ilev,jlev;
+  double dummy;
+  FILE *fp;
+
+  for(i=0;i<par->nSpecies;i++){
+    md[i].gir = malloc(sizeof(double)*md[i].nlev*md[i].nlev);
+    /* Read the pumping rate coefficients onto gir array */
+    for(ilev=0;ilev<md[i].nlev;ilev++){
+      for(jlev=0;jlev<md[i].nlev;jlev++){
+        md[i].gir[ilev*md[i].nlev+jlev] = 0.;
+      }
+    }
+    if((fp=fopen(par->girdatfile[i], "r")) != NULL){
+      while (fscanf(fp, "%d %d %lf", &ilev, &jlev, &dummy) != EOF) {
+        md[i].gir[(ilev-1)*md[i].nlev+jlev-1] = dummy;
+      }
+      fclose(fp);
+    }
+  }
+}
 
 /*....................................................................*/
 void molInit(configInfo *par, molData *md){
@@ -317,6 +324,9 @@ void molInit(configInfo *par, molData *md){
   readMolData(par, md, &allUniqueCollPartIds, &numUniqueCollPartsFound);
   setUpDensityAux(par, allUniqueCollPartIds, numUniqueCollPartsFound);
   free(allUniqueCollPartIds);
+  if(par->girdatfile!=NULL){
+    setUpGir(par, md);
+  }
   if(!par->lte_only){
     assignMolCollPartsToDensities(par, md);
 

--- a/src/molinit.c
+++ b/src/molinit.c
@@ -60,7 +60,7 @@ checkFirstLineMolDat(FILE *fp, char *moldatfile){
 void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds, int *numUniqueCollPartsFound){
   /* NOTE! allUniqueCollPartIds is malloc'd in the present function, but not freed. The calling program must free it elsewhere.
   */
-  int i,j,k,ilev,idummy,iline,numPartsAcceptedThisMol,ipart,collPartId,itemp,itrans;
+  int i,j,k,ilev,jlev,idummy,iline,numPartsAcceptedThisMol,ipart,collPartId,itemp,itrans;
   double dummy;
   _Bool cpWasFoundInUserList,previousCpFound;
   const int sizeI=200;
@@ -105,6 +105,7 @@ void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds, int *
     md[i].lal     = malloc(sizeof(int)   *md[i].nline);
     md[i].lau     = malloc(sizeof(int)   *md[i].nline);
     md[i].aeinst  = malloc(sizeof(double)*md[i].nline);
+    md[i].gir     = malloc(sizeof(double)*md[i].nlev*md[i].nlev);
     md[i].freq    = malloc(sizeof(double)*md[i].nline);
     md[i].beinstu = malloc(sizeof(double)*md[i].nline);
     md[i].beinstl = malloc(sizeof(double)*md[i].nline);
@@ -247,6 +248,20 @@ void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds, int *
     }
 
     fclose(fp);
+
+    /* Read the pumping rate coefficients onto gir array */
+    for(ilev=0;ilev<md[i].nlev;ilev++){
+      for(jlev=0;jlev<md[i].nlev;jlev++){
+        md[i].gir[ilev*md[i].nlev+jlev] = 0.;
+      }
+    }
+    if((fp=fopen(par->girdatfile[i], "r")) != NULL){
+      while (fscanf(fp, "%d %d %lf", &ilev, &jlev, &dummy) != EOF) {
+        md[i].gir[(ilev-1)*md[i].nlev+jlev-1] = dummy;
+      }
+      fclose(fp);
+    }
+
   } /* end loop over molecule index i */
 
   if((*numUniqueCollPartsFound)<=0){

--- a/src/stateq.c
+++ b/src/stateq.c
@@ -102,7 +102,7 @@ getMatrix(int id, gsl_matrix *matrix, molData *md, struct grid *gp, int ispec, g
         gsl_matrix_set(matrix,k,k,gsl_matrix_get(matrix,k,k)+gp[id].dens[di]*collPartMat[ipart].ctot[k]);
     }
     if(par->girdatfile!=NULL)
-    gsl_matrix_set(matrix,k,k,gsl_matrix_get(matrix,k,k)+girtot[k]);
+      gsl_matrix_set(matrix,k,k,gsl_matrix_get(matrix,k,k)+girtot[k]);
     for(l=0;l<md[ispec].nlev;l++){
       if(k!=l){
         for(ipart=0;ipart<md[ispec].npart;ipart++){
@@ -111,7 +111,7 @@ getMatrix(int id, gsl_matrix *matrix, molData *md, struct grid *gp, int ispec, g
             gsl_matrix_set(matrix,k,l,gsl_matrix_get(matrix,k,l)-gp[id].dens[di]*gsl_matrix_get(collPartMat[ipart].colli,l,k));
         }
         if(par->girdatfile!=NULL)
-        gsl_matrix_set(matrix,k,l,gsl_matrix_get(matrix,k,l)-md[ispec].gir[l*md[ispec].nlev+k]);
+          gsl_matrix_set(matrix,k,l,gsl_matrix_get(matrix,k,l)-md[ispec].gir[l*md[ispec].nlev+k]);
       }
     }
     gsl_matrix_set(matrix, md[ispec].nlev, k, 1.);


### PR DESCRIPTION
Added support for providing effective IR pumping rate coefficients in an
external file `girdatfile` for each radiating species. These coefficients can
be calculated from the contribution of cascading rotational levels
within vibration bands excited by IR solar radiation as described in
the case of comets by Bensch & Bergin 2004.  This effect is relevant
for cometary coma exposed to solar radiation.
