### PR TITLE
Hard-wired DIM==3 removed from ray-through-cells algorithm.

### DIFF
--- a/src/dims.h
+++ b/src/dims.h
@@ -1,0 +1,9 @@
+#ifndef DIMS_H
+#define DIMS_H
+
+#define DIM 3
+#define N_DIMS DIM
+
+#endif /* DIMS_H */
+
+

--- a/src/frees.c
+++ b/src/frees.c
@@ -9,7 +9,8 @@
 
 #include "lime.h"
 
-void freeConfig(configInfo par){
+void
+freeConfig(configInfo par){
   free(par.moldatfile);
   free(par.collPartIds);
   free(par.nMolWeights);
@@ -18,7 +19,8 @@ void freeConfig(configInfo par){
   free(par.gridDensMaxValues);
 }
 
-void freeGrid(const unsigned int numPoints, const unsigned short numSpecies\
+void
+freeGrid(const unsigned int numPoints, const unsigned short numSpecies\
   , struct grid *gp){
 
   unsigned int i_u;
@@ -82,7 +84,8 @@ freeMolData(const int nSpecies, molData *mol){
   }
 }
 
-void freeMolsWithBlends(struct molWithBlends *mols, const int numMolsWithBlends){
+void
+freeMolsWithBlends(struct molWithBlends *mols, const int numMolsWithBlends){
   int mi, li;
 
   if(mols != NULL){
@@ -121,7 +124,8 @@ freeParImg(const int nImages, inputPars *par, image *img){
   free(par->gridOutFiles);
 }
 
-void freePopulation(const unsigned short numSpecies, struct populations *pop){
+void
+freePopulation(const unsigned short numSpecies, struct populations *pop){
   if(pop != NULL){
     unsigned short i_s;
     for(i_s=0;i_s<numSpecies;i_s++){
@@ -134,7 +138,8 @@ void freePopulation(const unsigned short numSpecies, struct populations *pop){
   }
 }
 
-void freeSomeGridFields(const unsigned int numPoints, const unsigned short numSpecies\
+void
+freeSomeGridFields(const unsigned int numPoints, const unsigned short numSpecies\
   , struct grid *gp){
 
   unsigned int i_u;

--- a/src/grid2fits.c
+++ b/src/grid2fits.c
@@ -381,6 +381,27 @@ NOTES:
 }
 
 /*....................................................................*/
+int
+getColIndex(char **allColNames, const int maxNumCols, char *colName){
+  int i=0;
+  int colFound=0; /* -> bool */
+
+  while(i<maxNumCols && !colFound){
+    if(!strcmp(allColNames[i],colName))
+      colFound = 1;
+
+    i++;
+  }
+
+  if(!colFound){
+    if(!silent) bail_out("Column name not found - this should not happen.");
+    exit(1);
+  }
+
+  return i-1;
+}
+
+/*....................................................................*/
 void
 writeGridExtToFits(fitsfile *fptr, struct gridInfoType gridInfo\
   , struct grid *gp, unsigned int *firstNearNeigh\
@@ -626,27 +647,6 @@ Ok we have a bit of a tricky situation here in that the number of columns we wri
   free(allColNames);
   free(allColNumbers);
   free(colDataTypes);
-}
-
-/*....................................................................*/
-int
-getColIndex(char **allColNames, const int maxNumCols, char *colName){
-  int i=0;
-  int colFound=0; /* -> bool */
-
-  while(i<maxNumCols && !colFound){
-    if(!strcmp(allColNames[i],colName))
-      colFound = 1;
-
-    i++;
-  }
-
-  if(!colFound){
-    if(!silent) bail_out("Column name not found - this should not happen.");
-    exit(1);
-  }
-
-  return i-1;
 }
 
 /*....................................................................*/

--- a/src/lime.h
+++ b/src/lime.h
@@ -41,7 +41,8 @@
 #define omp_set_dynamic(int) 0
 #endif
 
-#define DIM 3
+#include "dims.h"
+
 #define VERSION	"1.6.1"
 #define DEFAULT_NTHREADS 1
 #ifndef NTHREADS /* Value passed from the LIME script */
@@ -282,28 +283,6 @@ struct cell {
   double centre[DIM];
 };
 
-/* This struct is meant to record all relevant information about the intersection between a ray (defined by a direction unit vector 'dir' and a starting position 'r') and a face of a Delaunay cell.
-*/
-typedef struct {
-  int fi;
-  /* The index (in the range {0...DIM}) of the face (and thus of the opposite vertex, i.e. the one 'missing' from the bary[] list of this face).
-  */
-  int orientation;
-  /* >0 means the ray exits, <0 means it enters, ==0 means the face is parallel to ray.
-  */
-  double bary[DIM], dist, collPar;
-  /* 'dist' is defined via r_int = r + dist*dir. 'collPar' is a measure of how close to any edge of the face r_int lies.
-  */
-} intersectType;
-
-typedef struct {
-  double r[DIM][DIM], centre[DIM];/*, norm[3], mat[1][1], det; */
-} faceType;
-
-typedef struct {
-  double xAxis[DIM], yAxis[DIM], r[3][2];
-} triangle2D;
-
 /* Some global variables */
 int silent;
 
@@ -327,9 +306,7 @@ _Bool	onlyBitsSet(const int flags, const int mask);
 
 void	assignMolCollPartsToDensities(configInfo*, molData*);
 void	binpopsout(configInfo*, struct grid*, molData*);
-int	buildRayCellChain(double*, double*, struct grid*, struct cell*, _Bool**, unsigned long, int, int, int, const double, unsigned long**, intersectType**, int*);
-void	calcAvRelLineAmp(struct grid*, int, int, double, double, double*);
-void	calcAvRelLineAmp_lin(struct grid*, int, int, double, double, double*);
+//void	buildGrid(configInfo*, struct grid*);
 void	calcFastExpRange(const int, const int, int*, int*, int*);
 void	calcGridCollRates(configInfo*, molData*, struct grid*);
 void	calcGridContDustOpacity(configInfo*, const double, double*, double*, const int, struct grid*);
@@ -339,28 +316,19 @@ void	calcGridMolDoppler(configInfo*, molData*, struct grid*);
 void	calcGridMolSpecNumDens(configInfo*, molData*, struct grid*);
 void	calcInterpCoeffs(configInfo*, struct grid*);
 void	calcInterpCoeffs_lin(configInfo*, struct grid*);
-void	calcLineAmpInterp(const double, const double, const double, double*);
-void	calcLineAmpSample(const double x[3], const double dx[3], const double, const double, double*, const int, const double, const double, double*);
 void	calcMolCMBs(configInfo*, molData*);
 void	calcSourceFn(double, const configInfo*, double*, double*);
 void	calcTableEntries(const int, const int);
-void	calcTriangleBaryCoords(double vertices[3][2], double, double, double barys[3]);
-triangle2D calcTriangle2D(faceType);
 void	checkGridDensities(configInfo*, struct grid*);
 void	checkUserDensWeights(configInfo*);
-void	continuumSetup(int, image*, molData*, configInfo*, struct grid*);
 void	delaunay(const int, struct grid*, const unsigned long, const _Bool, struct cell**, unsigned long*);
 void	distCalc(configInfo*, struct grid*);
-void	doBaryInterp(const intersectType, struct grid*, double*, unsigned long*, molData*, const int, gridInterp*);
-void	doSegmentInterp(gridInterp*, const int, molData*, const int, const double, const int);
-faceType extractFace(struct grid*, struct cell*, const unsigned long, const int);
 int	factorial(const int);
 double	FastExp(const float);
 void    fillErfTable();
 void	fit_d1fi(double, double, double*);
 void	fit_fi(double, double, double*);
 void	fit_rr(double, double, double*);
-int	followRayThroughDelCells(double*, double*, struct grid*, struct cell*, const unsigned long, const double, intersectType*, unsigned long**, intersectType**, int*);
 void	freeConfig(configInfo par);
 void	freeGrid(const unsigned int, const unsigned short, struct grid*);
 void	freeGridPointData(configInfo*, gridPointData*);
@@ -372,21 +340,17 @@ void	freeSomeGridFields(const unsigned int, const unsigned short, struct grid*);
 double  gaussline(const double, const double);
 void	getArea(configInfo*, struct grid*, const gsl_rng*);
 void	getclosest(double, double, double, long*, long*, double*, double*, double*);
-int	getColIndex(char**, const int, char*);
 void	getjbar(int, molData*, struct grid*, const int, configInfo*, struct blendInfo, int, gridPointData*, double*);
 void	getMass(configInfo*, struct grid*, const gsl_rng*);
 void	getmatrix(int, gsl_matrix*, molData*, struct grid*, int, gridPointData*);
-int	getNewEntryFaceI(const unsigned long, const struct cell);
 int	getNextEdge(double*, int, struct grid*, const gsl_rng*);
 void	getVelocities(configInfo *, struct grid *);
 void	getVelocities_pregrid(configInfo *, struct grid *);
 void	gridPopsInit(configInfo*, molData*, struct grid*);
 void	input(inputPars*, image*);
 double	interpolateKappa(const double, double*, double*, const int, gsl_spline*, gsl_interp_accel*);
-void	intersectLineTriangle(double*, double*, faceType, intersectType*);
 float	invSqrt(float);
 void	levelPops(molData*, configInfo*, struct grid*, int*, double*, double*, const int);
-void	line_plane_intersect(struct grid*, double*, int, int*, double*, double*, double);
 void	lineBlend(molData*, configInfo*, struct blendInfo*);
 void	LTE(configInfo*, struct grid*, molData*);
 void	lteOnePoint(molData*, const int, const double, double*);
@@ -419,8 +383,6 @@ void	stateq(int, struct grid*, molData*, const int, configInfo*, struct blendInf
 void	statistics(int, molData*, struct grid*, int*, double*, double*, int*);
 void	stokesangles(double*, double (*rotMat)[3], double*);
 double	taylor(const int, const float);
-void	traceray(rayData, const double, const int, configInfo*, struct grid*, molData*, image*, const double, const int, const double);
-void	traceray_smooth(rayData, const double, const int, configInfo*, struct grid*, molData*, image*, struct cell*, const unsigned long, const double, gridInterp gips[3], const int, const double, const int, const double);
 double	veloproject(const double*, const double*);
 void	write2Dfits(int, configInfo*, molData*, image*);
 void	write3Dfits(int, configInfo*, molData*, image*);

--- a/src/raythrucells.c
+++ b/src/raythrucells.c
@@ -5,88 +5,422 @@
  *  Copyright (C) 2006-2014 Christian Brinch
  *  Copyright (C) 2015-2016 The LIME development team
  *
+TODO:
  */
 
-#include "lime.h"
+#include "raythrucells.h"
 
-/*....................................................................*/
-int followRayThroughDelCells(double x[DIM], double dir[DIM], struct grid *gp\
-  , struct cell *dc, const unsigned long numCells, const double epsilon\
-  , intersectType *entryIntcpt, unsigned long **chainOfCellIds\
-  , intersectType **cellExitIntcpts, int *lenChainPtrs){
-  /*
-The present function follows a ray through a connected, convex set of Delaunay cells and returns information about the chain of cells it passes through. If the ray is found to pass through 1 or more cells, the function returns 0, indicating success; if not, it returns a non-zero value. The chain description consists of three pieces of information: (i) intercept information for the entry face of the first cell encountered; (ii) the IDs of the cells in the chain; (iii) intercept information for the exit face of the ith cell.
-  */
-
-  const int numFaces=DIM+1, maxNumEntryFaces=100;
-  int numEntryFaces, fi, entryFis[maxNumEntryFaces], i, status;
-  faceType face;
-  unsigned long dci, entryDcis[maxNumEntryFaces];
-  intersectType intcpt, entryIntcpts[maxNumEntryFaces];
-  _Bool *cellVisited=NULL;
-
-  /* Choose a set of starting faces by testing all the 'external' faces of cells which have some. */
-  numEntryFaces = 0;
-  for(dci=0;dci<numCells;dci++){
-    for(fi=0;fi<numFaces;fi++){
-      if(dc[dci].neigh[fi]==NULL){ /* means that this face lies on the outside of the model. */
-        /* Store points for this face: */
-        face = extractFace(gp, dc, dci, fi);
-
-        /* Now calculate the intercept: */
-        intersectLineTriangle(x, dir, face, &intcpt);
-        intcpt.fi = fi; /* Ultimately we need this so we can relate the bary coords for the face back to the Delaunay cell. */
-
-        if(intcpt.orientation<0){ /* it is an entry face. */
-          if(intcpt.collPar+epsilon>0.0){
-            if(numEntryFaces>maxNumEntryFaces){
-              if(!silent) bail_out("Too many entry faces.");
-              exit(1);
-            }
-
-            entryDcis[   numEntryFaces] = dci;
-            entryFis[    numEntryFaces] = fi;
-            entryIntcpts[numEntryFaces] = intcpt;
-            numEntryFaces++;
-          }
-        }
-      }
-    }
-  }
-
-  if(numEntryFaces<=0)
-    return 1;
-
-  *lenChainPtrs = 1024; /* This can be increased within followCellChain(). */
-  *chainOfCellIds  = malloc(sizeof(**chainOfCellIds) *(*lenChainPtrs));
-  *cellExitIntcpts = malloc(sizeof(**cellExitIntcpts)*(*lenChainPtrs));
-  cellVisited = malloc(sizeof(*cellVisited)*numCells);
-  for(dci=0;dci<numCells;dci++)
-    cellVisited[dci] = 0;
-
-  i = 0;
-  status = 1; /* default */
-  while(i<numEntryFaces && status>0){
-    status = buildRayCellChain(x, dir, gp, dc, &cellVisited, entryDcis[i], entryFis[i], 0, 0, epsilon, chainOfCellIds, cellExitIntcpts, lenChainPtrs);
-    i++;
-  }
-
-  if(status==0)
-    *entryIntcpt = entryIntcpts[i-1];
-  /* Note that the order of the bary coords, and the value of fi, are with reference to the vertx list of the _entered_ cell. This can't of course be any other way, because this ray enters this first cell from the exterior of the model, where there are no cells. For all the intersectType objects in the list cellExitIntcpts, the bary coords etc are with reference to the exited cell. */
-
-  free(cellVisited);
-
-  return status;
+void __attribute__((weak))
+error(int errCode, char *message){
+  printf("%s\n", message);
+  exit(1);
 }
 
 /*....................................................................*/
-int buildRayCellChain(double x[DIM], double dir[DIM], struct grid *gp\
-  , struct cell *dc, _Bool **cellVisited, unsigned long dci, int entryFaceI\
-  , int levelI, int nCellsInChain, const double epsilon\
-  , unsigned long **chainOfCellIds, intersectType **cellExitIntcpts, int *lenChainPtrs){
+faceType
+extractFace(double *vertexCoords, struct simplex *dc, const unsigned long dci\
+  , const int fi){
+  /* Given a simplex dc[dci] and the face index (in the range {0...N_DIMS}) fi, this returns the desired information about that face. Note that the ordering of the elements of face.r[] is the same as the ordering of the vertices of the simplex, dc[dci].vertx[]; just the vertex fi is omitted.
+
+Note that the element 'centre' of the faceType struct is mean to contain the spatial coordinates of the centre of the simplex, not of the face. This is designed to facilitate orientation of the face and thus to help determine whether rays which cross it are entering or exiting the simplex.
+ */
+
+  const int numFaces=N_DIMS+1;
+  int vi, vvi, di;
+  faceType face;
+  unsigned long gi;
+
+  vvi = 0;
+  for(vi=0;vi<numFaces;vi++){
+    if(vi!=fi){
+      gi = dc[dci].vertx[vi];
+      for(di=0;di<N_DIMS;di++){
+        face.r[vvi][di] = vertexCoords[N_DIMS*gi+di];
+      }
+      vvi++;
+    }
+  }
+
+  for(di=0;di<N_DIMS;di++)
+    face.simplexCentre[di] = dc[dci].centre[di];
+
+  return face;
+}
+
+/*....................................................................*/
+int
+getNewEntryFaceI(const unsigned long dci, const struct simplex newCell){
+  /* Finds the index of the old cell in the face list of the new cell. */
+
+  const int numFaces=N_DIMS+1;
+  _Bool matchFound = 0;
+  int ffi = 0, newEntryFaceI;
+
+  while(ffi<numFaces && matchFound==0){
+    if(newCell.neigh[ffi]!=NULL && newCell.neigh[ffi]->id==dci){
+      matchFound = 1;
+      newEntryFaceI = ffi;
+    }
+    ffi++;
+  }
+
+  /* Sanity check: */
+  if(!matchFound)
+    error(RTC_ERR_OLD_NOT_FOUND, "Cannot find old cell ID in new cell data.");
+
+  return newEntryFaceI;
+}
+
+/*....................................................................*/
+facePlusBasisType
+calcFaceInNMinus1(const int numVertices, faceType *face){
   /*
-This function is designed to follow a ray (defined by a starting locus 'x' and a direction vector 'dir') through a convex connected set of Delaunay cells. The function returns an integer status value directly, and two lists (plus their common length) via the argument interface: chainOfCellIds and cellExitIntcpts. Taken together, these lists define a chain of Delaunay cells traversed by the ray.
+Each of the faces of a polytope in N spatial dimensions is itself a polytope in N-1 dimensions. Each face can therefore be represented via the coordinates of its vertices expressed in an (N-1)-dimensional frame oriented so as to be parallel to the face. The function of the present routine is to perform this decomposition and to return both the (N-1)-dimensional frame (specified via the coordinates in N dimensions of its N-1 basis vectors) and the coordinates in it of each of the M face vertices. (If the face is simplicial, M==N.)
+
+The calling routine should call freeFacePlusBasis() after it is finished with the returned object.
+
+Note that numVertices (a.k.a. M) is expected to be >= N_DIMS (a.k.a. N). The thing would not make much sense otherwise.
+  */
+
+  facePlusBasisType facePlusBasis;
+  double vs[numVertices-1][N_DIMS],dotValue,norm;
+  int di,vi,i,j,ddi;
+
+  /* The first part of the routine is finding the components in N-space of the N-1 orthonormal axes parallel to the face. It is essentially a modified (i.e numerically stabler) Gram-schmidt orthonormalization of the first N-1 vectors from face vertex 0 to each of its other vertices. In pseudo-code, suppose we have N-1 vectors *v and want to orthonormalize them to *u:
+
+	for(i=0;i<N-1;i++){
+	  u[i] = v[i]
+	  for(j=0;j<i;j++){
+	    u[i] -= (u[i].u[j])*u[j]
+	  }
+	  u[i] /= |u[i]|
+	}
+
+  */
+  for(di=0;di<N_DIMS;di++)
+    facePlusBasis.origin[di] = (*face).r[0][di];
+
+  for(vi=0;vi<numVertices-1;vi++){
+    for(di=0;di<N_DIMS;di++)
+      vs[vi][di] = (*face).r[vi+1][di] - (*face).r[0][di];
+  }
+
+  for(i=0;i<N_DIMS-1;i++){
+    for(di=0;di<N_DIMS;di++)
+      facePlusBasis.axes[i][di] = vs[i][di];
+
+    for(j=0;j<i;j++){
+      dotValue = 0.0;
+      for(di=0;di<N_DIMS;di++)
+        dotValue += facePlusBasis.axes[i][di]*facePlusBasis.axes[j][di];
+      for(di=0;di<N_DIMS;di++)
+        facePlusBasis.axes[i][di] -= dotValue*facePlusBasis.axes[j][di];
+    }
+
+    norm = 0.0;
+    for(di=0;di<N_DIMS;di++){
+      norm += facePlusBasis.axes[i][di]*facePlusBasis.axes[i][di];
+    }
+    norm = 1.0/sqrt(norm);
+    for(di=0;di<N_DIMS;di++)
+      facePlusBasis.axes[i][di] *= norm;
+  }
+
+  /* Now we calculate the coords of each vertex in the N-1 system:
+  */
+  vi = 0;
+  for(ddi=0;ddi<N_DIMS-1;ddi++)
+    facePlusBasis.r[vi][ddi] = 0.0;
+
+  for(vi=1;vi<numVertices;vi++){
+    for(ddi=0;ddi<N_DIMS-1;ddi++){
+
+      dotValue = 0.0;
+      for(di=0;di<N_DIMS;di++)
+        dotValue += vs[vi-1][di]*facePlusBasis.axes[ddi][di];
+
+      facePlusBasis.r[vi][ddi] = dotValue;
+    }
+  }
+
+  return facePlusBasis;
+}
+
+/*....................................................................*/
+intersectType
+intersectLineWithFace(double *x, double *dir, faceType *face, const double epsilon){
+  /*
+This function calculates the intersection between a line and the face of a simplex oriented in that space. Obviously the number of dimensions of the space must be >=2. The intersection point may be expressed as
+
+	px_ = x_ + a*dir_
+
+where px_, x_ and dir_ are vectors and 'a' is a scalar. The routine returns the following information:
+	- The value of 'a'.
+	- The so-called barycentric coordinates (BC) of px_ in the face.
+
+The scalar 'a' is found as follows. We need the additional point y_ which can be any of the face vertices. We state the vector identity
+
+	a*dir_ = (y_ - x_) + (px_ - y_).
+
+Clearly (px_ - y_) is parallel to the face. If we take the scalar product of both sides with the vector n_ which is normal to the face we arrive at
+
+	a*dir_.n_ = (y_ - x_).n_ + (px_ - y_).n_.
+
+	          = (y_ - x_).n_ + 0.
+Thus
+	     (y_ - x_).n_
+	a = --------------.
+	       dir_.n_
+
+Notes:
+	* This routine works best when the sides of the face are not too disparate in size.
+
+	* There is, of course, no guarantee that the line actually intersects the face, even if the line and the face are non-parallel. There are also borderline cases, i.e. where the line passes close to a vertex, in which an exact calculation would show that the intersection occurs (or doesn't occur), but the imprecise computed value claims that it doesn't (or does). Intersection may be judged via the values of the barycentric coordinates (BC): if the BC all fall in the interval [0,1], the line intersects the face; if one of the BC is negative, it doesn't.
+  */
+  const double oneOnEpsilon=1.0/epsilon;
+  double vs[N_DIMS-1][N_DIMS],norm[N_DIMS],normDotDx, numerator, pxInFace[N_DIMS-1], tMat[N_DIMS-1][N_DIMS-1], bVec[N_DIMS-1], det;
+  int i,j,k,di,ci,ri,vi,ciOfMax,ciOfMin;
+  double testSumForCW=0.0,maxSingularValue,singularValue;
+  facePlusBasisType facePlusBasis;
+  char errStr[80];
+  intersectType intcpt;
+
+  for(vi=0;vi<N_DIMS-1;vi++){
+    for(di=0;di<N_DIMS;di++)
+      vs[vi][di] = (*face).r[vi+1][di]-(*face).r[0][di];
+  }
+
+  /* First calculate a normal vector to the face (note that it doesn't need to be of length==1).
+  */
+  if(N_DIMS==2){
+    norm[0] = vs[0][1];
+    norm[1] = vs[0][0];
+
+  }else if(N_DIMS==3){
+    /* Calculate norm via cross product. */
+    for(di=0;di<N_DIMS;di++){
+      j = (di+1)%N_DIMS;
+      k = (di+2)%N_DIMS;
+      norm[di] = vs[0][j]*vs[1][k] - vs[0][k]*vs[1][j];
+    }
+
+  }else{ /* Assume N_DIMS>3 */
+    /* Calculate norm via SVD. */
+    int status=0;
+    gsl_matrix *matrix = gsl_matrix_alloc(N_DIMS-1, N_DIMS);
+    gsl_matrix *svv    = gsl_matrix_alloc(N_DIMS,   N_DIMS);
+    gsl_vector *svs    = gsl_vector_alloc(N_DIMS);
+    gsl_vector *work   = gsl_vector_alloc(N_DIMS);
+
+    for(ci=0;ci<N_DIMS;ci++){
+      for(ri=0;ri<N_DIMS-1;ri++)
+        gsl_matrix_set(matrix, ri, ci, vs[ri][ci]);
+    }
+
+    status = gsl_linalg_SV_decomp(matrix, svv, svs, work);
+    if(status){
+      sprintf(errStr, "SVD decomposition failed (GSL error %d).", status);
+      error(RTC_ERR_SVD_FAIL, errStr);
+    }
+
+    /*
+Since we have N-1 equations in N unknowns, we would expect at least one of the N elements of svs to be zero (within rounding error). The column of svv which corresponds to this value should then be the normal vector which we require. We'll just check however that not more than 1 value of svs is zero.
+
+The GSL doco says that SV_decomp returns sorted svs values, but I prefer not to reply on that.
+    */
+
+    ci = 0;
+    ciOfMax = ci;
+    maxSingularValue = gsl_vector_get(svs,ci);
+    for(ci=1;ci<N_DIMS;ci++){
+      singularValue = gsl_vector_get(svs,ci);
+      if(singularValue>maxSingularValue){
+        ciOfMax = ci;
+        maxSingularValue = singularValue;
+      }
+    }
+
+    ciOfMin = -1; /* Impossible default. */
+    for(ci=0;ci<N_DIMS;ci++){
+      if(ci==ciOfMax) continue;
+
+      singularValue = gsl_vector_get(svs,ci);
+      if(singularValue*oneOnEpsilon<maxSingularValue){
+        if(ciOfMin>=0){
+          /* This is an error because it indicates that >1 singular values are 'small'. */
+          sprintf(errStr, "Simplex face does not span an N-1 subspace.");
+          error(RTC_ERR_NON_SPAN, errStr);
+        }
+
+        ciOfMin = ci;
+      }
+    }
+
+    for(di=0;di<N_DIMS;di++)
+      norm[di] = gsl_matrix_get(svv,di,ciOfMin);
+
+    gsl_vector_free(work);
+    gsl_vector_free(svs);
+    gsl_matrix_free(svv);
+    gsl_matrix_free(matrix);
+  }
+
+  /* Since we don't know a priori whether the vertices of the face are listed CW or ACW seen from inside the simplex, we will work this out by dotting the normal vector with a vector from the centre of the simplex to vertex 0 of the face. (A simplex is always convex so this ought to work.)
+  */
+  testSumForCW = 0.0;
+  for(di=0;di<N_DIMS;di++)
+    testSumForCW += norm[di]*((*face).r[0][di] - (*face).simplexCentre[di]);
+
+  if(testSumForCW<0.0){
+    for(di=0;di<N_DIMS;di++)
+      norm[di] *= -1.0;
+  }
+
+  /* Calculate the scalar (or dot) product between norm and dir.
+  */
+  normDotDx = 0.0;
+  for(di=0;di<N_DIMS;di++)
+    normDotDx += norm[di]*dir[di];
+
+  if(normDotDx>0.0){ /* it is an exit face. */
+    intcpt.orientation = 1;
+  }else if(normDotDx<0.0){ /* it is an entry face. */
+    intcpt.orientation = -1;
+  }else{ /* normDotDx==0.0, i.e. line and face are parallel. */
+    intcpt.orientation = 0;
+    for(di=0;di<N_DIMS;di++)
+      intcpt.bary[di] = 0.0;
+    intcpt.dist    = 0.0;
+    intcpt.collPar = 0.0;
+
+    return intcpt;
+  }
+
+  /* If we've got to here, we can be sure the line and the face are not parallel, and that we therefore expect meaningful results for the calculation of 'a'.
+  */
+  numerator = 0.0;
+  for(di=0;di<N_DIMS;di++)
+    numerator += norm[di]*((*face).r[0][di] - x[di]); /* n_.(y_ - x_) */
+
+  intcpt.dist = numerator/normDotDx;
+
+  /* In order to calculate the barycentric coordinates, we need to set up a N-1 coordinate basis in the plane of the face.
+  */
+  facePlusBasis = calcFaceInNMinus1(N_DIMS, face);
+
+  /* Now we want to express the intersection point in these coordinates:
+  */
+  for(i=0;i<N_DIMS-1;i++){
+    pxInFace[i] = 0.0;
+    for(di=0;di<N_DIMS;di++)
+      pxInFace[i] += (x[di] + intcpt.dist*dir[di] - facePlusBasis.origin[di])*facePlusBasis.axes[i][di];
+  }
+
+  /*
+The barycentric coordinates x_ = {L_1,L_2,...,L_{N-1}} are given by
+
+	T x_ = b_
+
+where T is an (N-1)*(N-1) matrix with entries
+
+	T_{i,j} = facePlusBasis.r[j+1][i] - facePlusBasis.r[0][i]
+
+and
+	b_i = pxInFace[i] - facePlusBasis.r[0][i].
+
+The final BC L_0 is given by
+
+	         _N-1
+	         \
+	L_0 = 1 - >    L_i.
+	         /_i=1
+  */
+
+  if(N_DIMS==2 || N_DIMS==3){
+    for(i=0;i<N_DIMS-1;i++){
+      for(j=0;j<N_DIMS-1;j++)
+        tMat[i][j] = facePlusBasis.r[j+1][i] - facePlusBasis.r[0][i];
+      bVec[i] = pxInFace[i] - facePlusBasis.r[0][i];
+    }
+
+    if(N_DIMS==2)
+      intcpt.bary[1] = bVec[0]/tMat[0][0];
+
+    else{ /* N_DIMS==3 */
+      det = tMat[0][0]*tMat[1][1] - tMat[0][1]*tMat[1][0];
+      /*** We're assuming that the triangle is not pathological, i.e that det!=0. */
+      intcpt.bary[1] = ( tMat[1][1]*bVec[0] - tMat[0][1]*bVec[1])/det;
+      intcpt.bary[2] = (-tMat[1][0]*bVec[0] + tMat[0][0]*bVec[1])/det;
+    }
+
+  }else{ /* Assume N_DIMS>3 */
+    int dummySignum,status=0;
+    gsl_matrix *gslT = gsl_matrix_alloc(N_DIMS-1, N_DIMS-1);
+    gsl_vector *gsl_x = gsl_vector_alloc(N_DIMS-1);
+    gsl_vector *gsl_b = gsl_vector_alloc(N_DIMS-1);
+    gsl_permutation *p = gsl_permutation_alloc(N_DIMS-1);
+
+    for(i=0;i<N_DIMS-1;i++){
+      for(j=0;j<N_DIMS-1;j++)
+        gsl_matrix_set(gslT, i, j, facePlusBasis.r[j+1][i] - facePlusBasis.r[0][i]);
+      gsl_vector_set(gsl_b, i, pxInFace[i] - facePlusBasis.r[0][i]);
+    }
+
+    status = gsl_linalg_LU_decomp(gslT,p,&dummySignum);
+    if(status){
+      sprintf(errStr, "LU decomposition failed (GSL error %d).", status);
+      error(RTC_ERR_LU_DECOMP_FAIL, errStr);
+    }
+
+    status = gsl_linalg_LU_solve(gslT,p,gsl_b,gsl_x);
+    if(status){
+      sprintf(errStr, "LU solver failed (GSL error %d).", status);
+      error(RTC_ERR_LU_SOLVE_FAIL, errStr);
+    }
+
+    for(i=0;i<N_DIMS-1;i++)
+      intcpt.bary[i+1] = gsl_vector_get(gsl_x,i);
+
+    gsl_permutation_free(p);
+    gsl_vector_free(gsl_b);
+    gsl_vector_free(gsl_x);
+    gsl_matrix_free(gslT);
+  }
+
+  intcpt.bary[0] = 1.0;
+  for(i=1;i<N_DIMS;i++)
+    intcpt.bary[0] -= intcpt.bary[i];
+
+  /* Finally, calculate the 'collision parameter':
+  */
+  di = 0;
+  if(intcpt.bary[di] < 0.5)
+    intcpt.collPar = intcpt.bary[di];
+  else
+    intcpt.collPar = 1.0 - intcpt.bary[di];
+
+  for(di=1;di<N_DIMS;di++){
+    if(intcpt.bary[di] < 0.5){
+      if(intcpt.bary[di] < intcpt.collPar)
+        intcpt.collPar = intcpt.bary[di];
+    }else{ /* intcpt.bary[di]>=0.5 */
+      if(1.0 - intcpt.bary[di] < intcpt.collPar)
+        intcpt.collPar = 1.0 - intcpt.bary[di];
+    }
+  }
+
+  return intcpt;
+}
+
+/*....................................................................*/
+int
+buildRayCellChain(double *x, double *dir, double *vertexCoords\
+  , struct simplex *dc, _Bool **cellVisited, unsigned long dci, int entryFaceI\
+  , int levelI, int nCellsInChain, const double epsilon\
+  , unsigned long **chainOfCellIds, intersectType **cellExitIntcpts\
+  , int *lenChainPtrs){
+  /*
+This function is designed to follow a ray (defined by a starting locus 'x' and a direction vector 'dir') through a convex connected set of cells (assumed simplicial). The function returns an integer status value directly, and two lists (plus their common length) via the argument interface: chainOfCellIds and cellExitIntcpts. Taken together, these lists define a chain of cells traversed by the ray.
 
 The task of determining which cells are traversed by the ray is simple in principle, but complications arise in computational practice due to the finite precision of floating-point calculations. Where the ray crosses a cell face near to one of its edges, numerical calculation of the 'impact parameter' may return an answer which is erroneous either way: i.e., a ray which just misses a face may be reported as hitting it, and vice versa. To deal with this, a distinction is made between impacts which are (i) 'good', that is far from any face edge; (ii) 'bad', i.e. clearly missing the face; and (iii) 'marginal', i.e. closer to the edge than some preset cutoff which is represented in the argument list by the number 'epsilon'. Note that a tally is kept of those cells which have already been tested for the current ray, and any face which abuts a neighbouring cell which has been visited already will be flagged as 'bad'.
 
@@ -109,10 +443,10 @@ The function terminates under the following conditions:
 
 At a successful termination, therefore, details of all the cells to the edge of the model are correctly stored in chainOfCellIds and cellExitIntcpts, and the number of these cells is returned in lenChainPtrs.
 
-***** Note that it is assumed here that a mis-indentification of the actual cell traversed by a ray will not ultimately matter to the external calling routine. This is only reasonable if whatever function or property is being sampled by the ray does not vary in a step function across cell boundaries. *****
+***** Note that it is assumed here that a mis-indentification of the actual cell traversed by a ray will not ultimately matter to the external calling routine. This is only reasonable if whatever function or property is being sampled by the ray does not vary in a stepwise manner at any cell boundary. *****
   */
 
-  const int numFaces=DIM+1;
+  const int numFaces=N_DIMS+1;
   _Bool followingSingleChain;
   const int bufferSize=1024;
   int numGoodExits, numMarginalExits, fi, goodExitFis[numFaces], marginalExitFis[numFaces], exitFi, i, status, newEntryFaceI;
@@ -137,10 +471,10 @@ At a successful termination, therefore, details of all the cells to the edge of 
     for(fi=0;fi<numFaces;fi++){
       if(fi!=entryFaceI && (dc[dci].neigh[fi]==NULL || !(*cellVisited)[dc[dci].neigh[fi]->id])){
         /* Store points for this face: */
-        face = extractFace(gp, dc, dci, fi);
+        face = extractFace(vertexCoords, dc, dci, fi);
 
         /* Now calculate the intercept: */
-        intersectLineTriangle(x, dir, face, &intcpt[fi]);
+        intcpt[fi] = intersectLineWithFace(x, dir, &face, epsilon);
         intcpt[fi].fi = fi; /* Ultimately we need this so we can relate the bary coords for the face back to the Delaunay cell. */
 
         if(intcpt[fi].orientation>0){ /* it is an exit face. */
@@ -156,8 +490,7 @@ At a successful termination, therefore, details of all the cells to the edge of 
     }
 
     if(numGoodExits>1){
-      if(!silent) bail_out("Some sort of bug: more than 1 firm candidate found for ray exit from cell.");
-      exit(1);
+      error(RTC_ERR_BUG, "Some sort of bug: more than 1 firm candidate found for ray exit from cell.");
 
     }else if(numGoodExits==1 || numMarginalExits==1){
       if(numGoodExits==1)
@@ -212,9 +545,9 @@ At a successful termination, therefore, details of all the cells to the edge of 
       newEntryFaceI = getNewEntryFaceI(dci, *(dc[dci].neigh[exitFi]));
 
       /* Now we dive into the branch: */
-      status = buildRayCellChain(x, dir, gp, dc, cellVisited, dc[dci].neigh[exitFi]->id\
-        , newEntryFaceI, levelI+1, nCellsInChain+1, epsilon\
-        , chainOfCellIds, cellExitIntcpts, lenChainPtrs);
+      status = buildRayCellChain(x, dir, vertexCoords, dc, cellVisited\
+        , dc[dci].neigh[exitFi]->id, newEntryFaceI, levelI+1, nCellsInChain+1\
+        , epsilon, chainOfCellIds, cellExitIntcpts, lenChainPtrs);
     }
     i++;
   }
@@ -223,304 +556,78 @@ At a successful termination, therefore, details of all the cells to the edge of 
 }
 
 /*....................................................................*/
-int getNewEntryFaceI(const unsigned long dci, const struct cell newCell){
-  /* Finds the index of the old cell in the face list of the new cell. */
+int
+followRayThroughCells(double *x, double *dir, double *vertexCoords\
+  , struct simplex *dc, const unsigned long numCells, const double epsilon\
+  , intersectType *entryIntcpt, unsigned long **chainOfCellIds\
+  , intersectType **cellExitIntcpts, int *lenChainPtrs){
+  /*
+The present function follows a ray through a connected, convex set of cells (assumed to be simplices) and returns information about the chain of cells it passes through. If the ray is found to pass through 1 or more cells, the function returns 0, indicating success; if not, it returns a non-zero value. The chain description consists of three pieces of information: (i) intercept information for the entry face of the first cell encountered; (ii) the IDs of the cells in the chain; (iii) intercept information for the exit face of the ith cell.
 
-  const int numFaces=DIM+1;
-  _Bool matchFound = 0;
-  int ffi = 0, newEntryFaceI;
+The calling routine should free chainOfCellIds, cellExitIntcpts & cellVisited after use.
 
-  while(ffi<numFaces && matchFound==0){
-    if(newCell.neigh[ffi]!=NULL && newCell.neigh[ffi]->id==dci){
-      matchFound = 1;
-      newEntryFaceI = ffi;
-    }
-    ffi++;
-  }
+Note that 'face' should be both allocated and freed by the calling routine. Only the values stored in it are altered by the present function.
+  */
 
-  /* Sanity check: */
-  if(!matchFound){
-    bail_out("Cannot find old cell ID in new cell data.");
-    exit(1);
-  }
-
-  return newEntryFaceI;
-}
-
-/*....................................................................*/
-faceType extractFace(struct grid *gp, struct cell *dc, const unsigned long dci, const int fi){
-  /* Given a simplex dc[dci] and the face index (in the range {0...DIM}) fi, this returns the desired information about that face. Note that the ordering of the elements of face.r[] is the same as the ordering of the vertices of the simplex, dc[dci].vertx[]; just the vertex fi is omitted.
-
-Note that the element 'centre' of the faceType struct is mean to contain the spatial coordinates of the centre of the simplex, not of the face. This is designed to facilitate orientation of the face and thus to help determine whether rays which cross it are entering or exiting the simplex.
- */
-
-  const int numFaces=DIM+1;
-  int vi, vvi, di;
-  struct grid point;
+  const int numFaces=N_DIMS+1, maxNumEntryFaces=100;
+  int numEntryFaces, fi, entryFis[maxNumEntryFaces], i, status;
   faceType face;
+  unsigned long dci, entryDcis[maxNumEntryFaces];//, trialDci;
+  intersectType intcpt, entryIntcpts[maxNumEntryFaces];
+  _Bool *cellVisited=NULL;
 
-  unsigned long gi;
+  /* Choose a set of starting faces by testing all the 'external' faces of cells which have some. */
+  numEntryFaces = 0;
+  for(dci=0;dci<numCells;dci++){
+    for(fi=0;fi<numFaces;fi++){
+      if(dc[dci].neigh[fi]==NULL){ /* means that this face lies on the outside of the model. */
+        /* Store points for this face: */
+        face = extractFace(vertexCoords, dc, dci, fi);
 
-  vvi = 0;
-  for(vi=0;vi<numFaces;vi++){
-    if(vi!=fi){
-      gi = dc[dci].vertx[vi]->id;
-      point = gp[gi];
-      for(di=0;di<DIM;di++){
-        face.r[vvi][di] = point.x[di];
+        /* Now calculate the intercept: */
+        intcpt = intersectLineWithFace(x, dir, &face, epsilon);
+        intcpt.fi = fi; /* Ultimately we need this so we can relate the bary coords for the face back to the Delaunay cell. */
+
+        if(intcpt.orientation<0){ /* it is an entry face. */
+          if(intcpt.collPar+epsilon>0.0){
+            if(numEntryFaces>maxNumEntryFaces)
+              error(RTC_ERR_TOO_MANY_ENTRY, "Too many entry faces.");
+
+            entryDcis[   numEntryFaces] = dci;
+            entryFis[    numEntryFaces] = fi;
+            entryIntcpts[numEntryFaces] = intcpt;
+            entryIntcpts[numEntryFaces] = intcpt;
+            numEntryFaces++;
+          }
+        }
       }
-      vvi++;
     }
   }
 
-  for(di=0;di<DIM;di++){
-    face.centre[di] = dc[dci].centre[di];
+  if(numEntryFaces<=0)
+    return 1;
+
+  *lenChainPtrs = 1024; /* This can be increased within followCellChain(). */
+  *chainOfCellIds  = malloc(sizeof(**chainOfCellIds) *(*lenChainPtrs));
+  *cellExitIntcpts = malloc(sizeof(**cellExitIntcpts)*(*lenChainPtrs));
+  cellVisited = malloc(sizeof(*cellVisited)*numCells);
+  for(dci=0;dci<numCells;dci++)
+    cellVisited[dci] = 0;
+
+  i = 0;
+  status = 1; /* default */
+  while(i<numEntryFaces && status>0){
+    status = buildRayCellChain(x, dir, vertexCoords, dc, &cellVisited\
+      , entryDcis[i], entryFis[i], 0, 0, epsilon, chainOfCellIds, cellExitIntcpts, lenChainPtrs);
+    i++;
   }
 
-  return face;
-}
+  if(status==0)
+    *entryIntcpt = entryIntcpts[i-1];
+  /* Note that the order of the bary coords, and the value of fi, are with reference to the vertx list of the _entered_ cell. This can't of course be any other way, because this ray enters this first cell from the exterior of the model, where there are no cells. For all the intersectType objects in the list cellExitIntcpts, the bary coords etc are with reference to the exited cell. */
 
-/*....................................................................*/
-void intersectLineTriangle(double x[3], double dir[3], faceType face\
-  , intersectType *intcpt){
-  /*
-This function calculates the intersection between a line in 3 space and a triangle oriented in that space. The intersection point may be expressed as
+  free(cellVisited);
 
-	px = x + a*dir
-
-where px, x and dir are vectors and 'a' is a scalar. The routine returns the following information:
-	- The value of 'a'.
-	- The so-called barycentric coordinates (BC) of px in the triangle.
-
-This routine works best when the sides of the triangle are not too disparate in size.
-
-Notes:
-	* The line and the triangle may be parallel. In this case, the function returns 1; otherwise 0.
-
-	* There is, of course, no guarantee that the line actually intersects the triangle, even if the line and the triangular plane intersect. There are also borderline cases, i.e. where the line passes close to a vertex, in which an exact calculation would show that the intersection occurs (or doesn't occur), but the imprecise computed value claims that it doesn't (or does). Intersection may be judged via the values of the barycentric coordinates: if these all fall in the interval [0,1], the line intersects the triangle; if one of the BC is negative, it doesn't.
-
-***** NOTE ***** that the intersectType now includes a field for the index of the face. This is not known to or supplied by the present function, so it sets it to -1 just to avoid an uninitialized value.
-  */
-
-  const int numDims=3;
-  double norm[numDims], normDotDx, numerator, px2D[numDims-1], mat[numDims-1][numDims-1], vec[numDims-1], det;
-  int j, k, di;
-  double testSumForCW=0.0;
-  triangle2D face2D;
-
-  intcpt->fi = -1;
-
-  /* First calculate a normal vector to the triangle from the cross product. Since we don't know a priori whether the vertices of the face are listed CW or ACW seen from inside the cell, we will work this out by dotting the norm vector with a vector from the centre of the cell to vertex 0.
-  */
-  for(di=0;di<numDims;di++){
-    j = (di+1)%numDims;
-    k = (di+2)%numDims;
-    norm[di] = (face.r[1][j]-face.r[0][j])*(face.r[2][k]-face.r[0][k])\
-             - (face.r[1][k]-face.r[0][k])*(face.r[2][j]-face.r[0][j]);
-
-    testSumForCW += norm[di]*(face.r[0][di] - face.centre[di]);
-  }
-
-  if(testSumForCW<0.0){
-    for(di=0;di<numDims;di++)
-      norm[di] *= -1.0;
-  }
-
-  /* Calculate the scalar (or dot) product between norm and dir.
-  */
-  normDotDx = norm[0]*dir[0] + norm[1]*dir[1] + norm[2]*dir[2];
-
-  if(normDotDx>0.0){ /* it is an exit face. */
-    intcpt->orientation = 1;
-  }else if(normDotDx<0.0){ /* it is an entry face. */
-    intcpt->orientation = -1;
-  }else{ /* normDotDx==0.0, i.e. line and plane are parallel. */
-    intcpt->orientation = 0;
-    intcpt->bary[0] = 0.0;
-    intcpt->bary[1] = 0.0;
-    intcpt->bary[2] = 0.0;
-    intcpt->dist    = 0.0;
-    intcpt->collPar = 0.0;
-
-    return;
-  }
-
-  /* If we've got to here, we can be sure the line and plane are not parallel, and that we therefore expect meaningful results. */
-
-  numerator = norm[0]*(face.r[0][0] - x[0])\
-            + norm[1]*(face.r[0][1] - x[1])\
-            + norm[2]*(face.r[0][2] - x[2]);
-
-  intcpt->dist = numerator/normDotDx;
-
-  /* In order to calculate the barycentric coordinates, we need to set up a 2D coordinate basis in the plane of the triangle. I'll define the X axis as 10^, where for short I use the generic notation ji_ to mean the vector (tri[j]-tri[i]), and ji^ to mean the unit vector in the same direction. The Y axis is the unit vector in the direction (20_ - (20_.10^)*10^).
-  */
-  face2D = calcTriangle2D(face);
-
-  /* Now we want to express the intersection point in these coordinates:
-  */
-  px2D[0] = (x[0] + intcpt->dist*dir[0] - face.r[0][0])*face2D.xAxis[0]\
-          + (x[1] + intcpt->dist*dir[1] - face.r[0][1])*face2D.xAxis[1]\
-          + (x[2] + intcpt->dist*dir[2] - face.r[0][2])*face2D.xAxis[2];
-  px2D[1] = (x[0] + intcpt->dist*dir[0] - face.r[0][0])*face2D.yAxis[0]\
-          + (x[1] + intcpt->dist*dir[1] - face.r[0][1])*face2D.yAxis[1]\
-          + (x[2] + intcpt->dist*dir[2] - face.r[0][2])*face2D.yAxis[2];
-
-  /*
-The barycentric coordinates (L0,L1,L2) are given by
-
-	(tri2D[0][0]-tri2D[2][0]  tri2D[1][0]-tri2D[2][0]) (L0)   (px2D[0]-tri2D[2][0])
-	(                                                )*(  ) = (                   ),
-	(tri2D[0][1]-tri2D[2][1]  tri2D[1][1]-tri2D[2][1]) (L1)   (px2D[1]-tri2D[2][1])
-
-with L2 = 1 - L0 - L1.
-  */
-  mat[0][0] = face2D.r[0][0]-face2D.r[2][0];
-  mat[0][1] = face2D.r[1][0]-face2D.r[2][0];
-  mat[1][0] = face2D.r[0][1]-face2D.r[2][1];
-  mat[1][1] = face2D.r[1][1]-face2D.r[2][1];
-  vec[0] = px2D[0]-face2D.r[2][0];
-  vec[1] = px2D[1]-face2D.r[2][1];
-  det = mat[0][0]*mat[1][1] - mat[0][1]*mat[1][0];
-  /*** We're assuming that the triangle is not pathological, i.e that det!=0. */
-  intcpt->bary[0] = ( mat[1][1]*vec[0] - mat[0][1]*vec[1])/det;
-  intcpt->bary[1] = (-mat[1][0]*vec[0] + mat[0][0]*vec[1])/det;
-  intcpt->bary[2] = 1.0 - intcpt->bary[0] - intcpt->bary[1];
-
-  di = 0;
-  if(intcpt->bary[di] < 0.5)
-    intcpt->collPar = intcpt->bary[di];
-  else
-    intcpt->collPar = 1.0 - intcpt->bary[di];
-
-  for(di=1;di<numDims;di++){
-    if(intcpt->bary[di] < 0.5){
-      if(intcpt->bary[di] < intcpt->collPar)
-        intcpt->collPar = intcpt->bary[di];
-    }else{ /* intcpt->bary[di]>=0.5 */
-      if(1.0 - intcpt->bary[di] < intcpt->collPar)
-        intcpt->collPar = 1.0 - intcpt->bary[di];
-    }
-  }
-
-  return;
-}
-
-/*....................................................................*/
-triangle2D calcTriangle2D(faceType face){
-/**** all this could be precalculated (norm and mat too). */
-
-  triangle2D face2D;
-  double lengthX, lengthY, dotResult;
-
-  face2D.xAxis[0] = face.r[1][0]-face.r[0][0];
-  face2D.xAxis[1] = face.r[1][1]-face.r[0][1];
-  face2D.xAxis[2] = face.r[1][2]-face.r[0][2];
-  lengthX = sqrt(face2D.xAxis[0]*face2D.xAxis[0]\
-               + face2D.xAxis[1]*face2D.xAxis[1]\
-               + face2D.xAxis[2]*face2D.xAxis[2]);
-  face2D.xAxis[0] /= lengthX;
-  face2D.xAxis[1] /= lengthX;
-  face2D.xAxis[2] /= lengthX;
-
-  dotResult = face2D.xAxis[0]*(face.r[2][0]-face.r[0][0])\
-            + face2D.xAxis[1]*(face.r[2][1]-face.r[0][1])\
-            + face2D.xAxis[2]*(face.r[2][2]-face.r[0][2]);
-
-  face2D.yAxis[0] = (face.r[2][0]-face.r[0][0]) - dotResult*face2D.xAxis[0];
-  face2D.yAxis[1] = (face.r[2][1]-face.r[0][1]) - dotResult*face2D.xAxis[1];
-  face2D.yAxis[2] = (face.r[2][2]-face.r[0][2]) - dotResult*face2D.xAxis[2];
-  lengthY = sqrt(face2D.yAxis[0]*face2D.yAxis[0]\
-               + face2D.yAxis[1]*face2D.yAxis[1]\
-               + face2D.yAxis[2]*face2D.yAxis[2]);
-  face2D.yAxis[0] /= lengthY;
-  face2D.yAxis[1] /= lengthY;
-  face2D.yAxis[2] /= lengthY;
-
-  /* The expressions for the triangle vertices in this basis are simple:
-  */
-  face2D.r[0][0] = 0.0;
-  face2D.r[0][1] = 0.0;
-  face2D.r[1][0] = lengthX;
-  face2D.r[1][1] = 0.0;
-  face2D.r[2][0] = dotResult;
-  face2D.r[2][1] = lengthY;
-
-  return face2D;
-}
-
-/*....................................................................*/
-void doBaryInterp(const intersectType intcpt, struct grid *gp\
-  , double xCmpntsRay[3], unsigned long gis[3]\
-  , molData *md, const int numMols, gridInterp *gip){
-
-  int di,molI,levelI;
-
-  (*gip).xCmpntRay = intcpt.bary[0]*xCmpntsRay[0]\
-                   + intcpt.bary[1]*xCmpntsRay[1]\
-                   + intcpt.bary[2]*xCmpntsRay[2];
-  for(di=0;di<DIM;di++){
-    (*gip).x[di] = intcpt.bary[0]*gp[gis[0]].x[di]\
-                 + intcpt.bary[1]*gp[gis[1]].x[di]\
-                 + intcpt.bary[2]*gp[gis[2]].x[di];
-  }
-
-  for(di=0;di<3;di++){ /* 3 not DIM, because a B field only makes sense in 3 dimensions. */
-/* ****** Maybe some test of DIM==3?? Would need to be systematic across the entire code..? */
-    (*gip).B[di] = intcpt.bary[0]*gp[gis[0]].B[di]\
-                 + intcpt.bary[1]*gp[gis[1]].B[di]\
-                 + intcpt.bary[2]*gp[gis[2]].B[di];
-  }
-
-  for(molI=0;molI<numMols;molI++){
-    (*gip).mol[molI].binv = intcpt.bary[0]*gp[gis[0]].mol[molI].binv\
-                          + intcpt.bary[1]*gp[gis[1]].mol[molI].binv\
-                          + intcpt.bary[2]*gp[gis[2]].mol[molI].binv;
-
-    for(levelI=0;levelI<md[molI].nlev;levelI++){
-      (*gip).mol[molI].specNumDens[levelI]\
-        = intcpt.bary[0]*gp[gis[0]].mol[molI].specNumDens[levelI]\
-        + intcpt.bary[1]*gp[gis[1]].mol[molI].specNumDens[levelI]\
-        + intcpt.bary[2]*gp[gis[2]].mol[molI].specNumDens[levelI];
-    }
-  }
-
-  (*gip).cont.dust = intcpt.bary[0]*gp[gis[0]].cont.dust\
-                   + intcpt.bary[1]*gp[gis[1]].cont.dust\
-                   + intcpt.bary[2]*gp[gis[2]].cont.dust;
-
-  (*gip).cont.knu  = intcpt.bary[0]*gp[gis[0]].cont.knu\
-                   + intcpt.bary[1]*gp[gis[1]].cont.knu\
-                   + intcpt.bary[2]*gp[gis[2]].cont.knu;
-}
-
-/*....................................................................*/
-void doSegmentInterp(gridInterp gips[3], const int iA, molData *md\
-  , const int numMols, const double oneOnNumSegments, const int si){
-
-  const double fracA = (si + 0.5)*oneOnNumSegments, fracB = 1.0 - fracA;
-  const int iB = 1 - iA;
-  int di,molI,levelI;
-
-  gips[2].xCmpntRay = fracA*gips[iB].xCmpntRay + fracB*gips[iA].xCmpntRay; /* This does not seem to be used. */
-
-  for(di=0;di<DIM;di++){
-    gips[2].x[di] = fracA*gips[iB].x[di] + fracB*gips[iA].x[di];
-  }
-  for(di=0;di<3;di++){ /* 3 not DIM, because a B field only makes sense in 3 dimensions. */
-    gips[2].B[di] = fracA*gips[iB].B[di] + fracB*gips[iA].B[di];
-  }
-
-  for(molI=0;molI<numMols;molI++){
-    gips[2].mol[molI].binv = fracA*gips[iB].mol[molI].binv + fracB*gips[iA].mol[molI].binv;
-
-    for(levelI=0;levelI<md[molI].nlev;levelI++){
-      gips[2].mol[molI].specNumDens[levelI] = fracA*gips[iB].mol[molI].specNumDens[levelI]\
-                                            + fracB*gips[iA].mol[molI].specNumDens[levelI];
-    }
-  }
-
-  gips[2].cont.dust = fracA*gips[iB].cont.dust + fracB*gips[iA].cont.dust;
-  gips[2].cont.knu  = fracA*gips[iB].cont.knu  + fracB*gips[iA].cont.knu;
+  return status;
 }
 

--- a/src/raythrucells.c
+++ b/src/raythrucells.c
@@ -581,12 +581,23 @@ The argument facePtrs may be set to NULL, in which case the function will constr
 	}
 	status = followRayThroughCells(... &facePtrs, ...);
 
+Note finally that if facePtrs is supplied non-NULL, vertexCoords may be left at NULL. If  is filled, it should be malloc'd as
+
+	vertexCoords = malloc(sizeof(double)*numDims*numPoints);
+
+and filled as
+
+	for(i=0;i<numPoints;i++)
+	  for(j=0;j<numDims;j++)
+	    vertexCoords[numDims*i+j] = // grid point i, coordinate j
+
+
   */
 
   const int numFaces=numDims+1, maxNumEntryFaces=100;
   int numEntryFaces, fi, entryFis[maxNumEntryFaces], i, status;
   faceType *pFace;
-  unsigned long dci, entryDcis[maxNumEntryFaces];//, trialDci;
+  unsigned long dci, entryDcis[maxNumEntryFaces];
   intersectType intcpt, entryIntcpts[maxNumEntryFaces];
   _Bool *cellVisited=NULL;
 

--- a/src/raythrucells.h
+++ b/src/raythrucells.h
@@ -1,0 +1,72 @@
+/*
+ *  raythrucells.h
+ *  This file is part of LIME, the versatile line modeling engine
+ *
+ *  Copyright (C) 2006-2014 Christian Brinch
+ *  Copyright (C) 2015-2016 The LIME development team
+ *
+ */
+
+#ifndef RAYTHRUCELLS_H
+#define RAYTHRUCELLS_H
+
+#include <stdio.h>
+#include <math.h>
+#include <gsl/gsl_matrix.h>
+#include <gsl/gsl_linalg.h>
+
+#include "dims.h" /* Should define the macro N_DIMS which specifies the number of spatial dimensions. */
+
+/* Error codes:
+*/
+#define RTC_ERR_SVD_FAIL	0
+#define RTC_ERR_NON_SPAN	1
+#define RTC_ERR_LU_DECOMP_FAIL	2
+#define RTC_ERR_LU_SOLVE_FAIL	3
+#define RTC_ERR_TOO_MANY_ENTRY	4
+#define RTC_ERR_BUG		5
+#define RTC_ERR_OLD_NOT_FOUND	6
+
+
+/* In the following comments, N is short for N_DIMS, the number of spatial dimensions. */
+
+/* NOTE that it is assumed that vertx[i] is opposite the face that abuts with neigh[i] for all i.
+*/ 
+struct simplex {
+  unsigned long id;
+  unsigned long vertx[N_DIMS+1];
+  double centre[N_DIMS];
+  struct simplex *neigh[N_DIMS+1]; /* An entry ==NULL flags an external face. */
+};
+
+/* This struct is meant to record all relevant information about the intersection between a ray (defined by a direction unit vector 'dir' and a starting position 'r') and a face of a simplex.
+*/
+typedef struct {
+  int fi;
+  /* The index (in the range {0...N}) of the face (and thus of the opposite vertex, i.e. the one 'missing' from the bary[] list of this face).
+  */
+  int orientation;
+  /* >0 means the ray exits, <0 means it enters, ==0 means the face is parallel to ray.
+  */
+  double bary[N_DIMS], dist, collPar;
+  /* 'dist' is defined via r_int = r + dist*dir. 'collPar' is a measure of how close to any edge of the face r_int lies.
+  */
+} intersectType;
+
+typedef struct {
+  double r[N_DIMS][N_DIMS], simplexCentre[N_DIMS];
+  /* 'r' is a list of the the N vertices of the face, each of which has N cartesian components. 'simplexCentre' is a convenience pointer which gives the location of the geometric centre of the simplex. */
+} faceType;
+
+typedef struct {
+  double axes[N_DIMS-1][N_DIMS], r[N_DIMS][N_DIMS-1], origin[N_DIMS];
+  /* 'r' expresses the location of the N vertices of a simplicial polytope face in N-space, in terms of components along the N-1 orthogonal axes in the sub-plane of the face. Thus you should malloc r as r[N][N-1]. */
+} facePlusBasisType;
+
+int	followRayThroughCells(double *x, double *dir\
+  , double *vertexCoords, struct simplex *dc, const unsigned long numCells\
+  , const double epsilon, intersectType *entryIntcpt, unsigned long **chainOfCellIds\
+  , intersectType **cellExitIntcpts, int *lenChainPtrs);
+
+#endif /* RAYTHRUCELLS_H */
+

--- a/src/raythrucells.h
+++ b/src/raythrucells.h
@@ -63,9 +63,15 @@ typedef struct {
   /* 'r' expresses the location of the N vertices of a simplicial polytope face in N-space, in terms of components along the N-1 orthogonal axes in the sub-plane of the face. Thus you should malloc r as r[N][N-1]. */
 } facePlusBasisType;
 
+typedef struct{
+  faceType *faces,*(*facePtrs[N_DIMS+1]);
+} faceListType;
+
+faceType *extractFace(const int numDims, double *vertexCoords, struct simplex *dc\
+  , const unsigned long dci, const int fi);
 int	followRayThroughCells(const int numDims, double *x, double *dir\
   , double *vertexCoords, struct simplex *dc, const unsigned long numCells\
-  , const double epsilon, intersectType *entryIntcpt, unsigned long **chainOfCellIds\
+  , const double epsilon, faceType **facePtrs[N_DIMS+1], intersectType *entryIntcpt, unsigned long **chainOfCellIds\
   , intersectType **cellExitIntcpts, int *lenChainPtrs);
 
 #endif /* RAYTHRUCELLS_H */

--- a/src/raythrucells.h
+++ b/src/raythrucells.h
@@ -15,7 +15,7 @@
 #include <gsl/gsl_matrix.h>
 #include <gsl/gsl_linalg.h>
 
-#include "dims.h" /* Should define the macro N_DIMS which specifies the number of spatial dimensions. */
+#include "dims.h" /* Should define the macro N_DIMS which specifies the number of spatial dimensions. Note that this is a _maximum_ value, the actual value 'numDims' which is passed via the function interfaces may be <= N_DIMS. */
 
 /* Error codes:
 */
@@ -63,7 +63,7 @@ typedef struct {
   /* 'r' expresses the location of the N vertices of a simplicial polytope face in N-space, in terms of components along the N-1 orthogonal axes in the sub-plane of the face. Thus you should malloc r as r[N][N-1]. */
 } facePlusBasisType;
 
-int	followRayThroughCells(double *x, double *dir\
+int	followRayThroughCells(const int numDims, double *x, double *dir\
   , double *vertexCoords, struct simplex *dc, const unsigned long numCells\
   , const double epsilon, intersectType *entryIntcpt, unsigned long **chainOfCellIds\
   , intersectType **cellExitIntcpts, int *lenChainPtrs);

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -376,7 +376,7 @@ This version of traceray implements a new algorithm in which the population valu
 
   /* Find the chain of cells the ray passes through.
   */
-  status = followRayThroughCells(x, dir, vertexCoords, dc, numCells, epsilon\
+  status = followRayThroughCells(DIM, x, dir, vertexCoords, dc, numCells, epsilon\
     , &entryIntcptFirstCell, &chainOfCellIds, &cellExitIntcpts, &lenChainPtrs);
 
   if(status!=0){

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -377,7 +377,7 @@ This version of traceray implements a new algorithm in which the population valu
   /* Find the chain of cells the ray passes through.
   */
   status = followRayThroughCells(DIM, x, dir, vertexCoords, dc, numCells, epsilon\
-    , &entryIntcptFirstCell, &chainOfCellIds, &cellExitIntcpts, &lenChainPtrs);
+    , NULL, &entryIntcptFirstCell, &chainOfCellIds, &cellExitIntcpts, &lenChainPtrs);
 
   if(status!=0){
     free(chainOfCellIds);

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -7,13 +7,15 @@
  *
 TODO:
   - In raytrace(), look at rearranging the code to do the qhull step before choosing the rays. This would allow cells with all vertices outside the image boundaries to be excluded. If the image is much smaller than the model, this could lead to significant savings in time. The only downside might be memory useage...
+  - In raytrace(), for par->traceRayAlgorithm==1, in theory we could deduce the cell geometry via the grid-point neighbour linkage, without needing to call delaunay() again.
  */
 
 #include "lime.h"
-
+#include "raythrucells.h"
 
 /*....................................................................*/
-void calcLineAmpSample(const double x[3], const double dx[3], const double ds\
+void
+calcLineAmpSample(const double x[3], const double dx[3], const double ds\
   , const double binv, double *projVels, const int nSteps\
   , const double oneOnNSteps, const double deltav, double *vfac){
   /*
@@ -39,7 +41,8 @@ The bulk velocity of the model material can vary significantly with position, th
 }
 
 /*....................................................................*/
-void calcLineAmpInterp(const double projVelRay, const double binv\
+void
+calcLineAmpInterp(const double projVelRay, const double binv\
   , const double deltav, double *vfac){
   /*
 The bulk velocity of the model material can vary significantly with position, thus so can the value of the line-shape function at a given frequency and direction. The present function calculates 'vfac', an approximate average of the line-shape function along a path of length ds in the direction of the line of sight.
@@ -90,7 +93,8 @@ This function returns ds as the (always positive-valued) distance between the pr
 }
 
 /*....................................................................*/
-void traceray(rayData ray, const double local_cmb, const int im\
+void
+traceray(rayData ray, const double local_cmb, const int im\
   , configInfo *par, struct grid *gp, molData *md, image *img\
   , const double cutoff, const int nSteps, const double oneOnNSteps){
   /*
@@ -250,9 +254,84 @@ Note that the algorithm employed here is similar to that employed in the functio
 }
 
 /*....................................................................*/
+void doBaryInterp(const intersectType intcpt, struct grid *gp\
+  , double xCmpntsRay[3], unsigned long gis[3]\
+  , molData *md, const int numMols, gridInterp *gip){
+
+  int di,molI,levelI;
+
+  (*gip).xCmpntRay = intcpt.bary[0]*xCmpntsRay[0]\
+                   + intcpt.bary[1]*xCmpntsRay[1]\
+                   + intcpt.bary[2]*xCmpntsRay[2];
+  for(di=0;di<DIM;di++){
+    (*gip).x[di] = intcpt.bary[0]*gp[gis[0]].x[di]\
+                 + intcpt.bary[1]*gp[gis[1]].x[di]\
+                 + intcpt.bary[2]*gp[gis[2]].x[di];
+  }
+
+  for(di=0;di<3;di++){ /* 3 not DIM, because a B field only makes sense in 3 dimensions. */
+/* ****** Maybe some test of DIM==3?? Would need to be systematic across the entire code..? */
+    (*gip).B[di] = intcpt.bary[0]*gp[gis[0]].B[di]\
+                 + intcpt.bary[1]*gp[gis[1]].B[di]\
+                 + intcpt.bary[2]*gp[gis[2]].B[di];
+  }
+
+  for(molI=0;molI<numMols;molI++){
+    (*gip).mol[molI].binv = intcpt.bary[0]*gp[gis[0]].mol[molI].binv\
+                          + intcpt.bary[1]*gp[gis[1]].mol[molI].binv\
+                          + intcpt.bary[2]*gp[gis[2]].mol[molI].binv;
+
+    for(levelI=0;levelI<md[molI].nlev;levelI++){
+      (*gip).mol[molI].specNumDens[levelI]\
+        = intcpt.bary[0]*gp[gis[0]].mol[molI].specNumDens[levelI]\
+        + intcpt.bary[1]*gp[gis[1]].mol[molI].specNumDens[levelI]\
+        + intcpt.bary[2]*gp[gis[2]].mol[molI].specNumDens[levelI];
+    }
+  }
+
+  (*gip).cont.dust = intcpt.bary[0]*gp[gis[0]].cont.dust\
+                   + intcpt.bary[1]*gp[gis[1]].cont.dust\
+                   + intcpt.bary[2]*gp[gis[2]].cont.dust;
+
+  (*gip).cont.knu  = intcpt.bary[0]*gp[gis[0]].cont.knu\
+                   + intcpt.bary[1]*gp[gis[1]].cont.knu\
+                   + intcpt.bary[2]*gp[gis[2]].cont.knu;
+}
+
+/*....................................................................*/
+void doSegmentInterp(gridInterp gips[3], const int iA, molData *md\
+  , const int numMols, const double oneOnNumSegments, const int si){
+
+  const double fracA = (si + 0.5)*oneOnNumSegments, fracB = 1.0 - fracA;
+  const int iB = 1 - iA;
+  int di,molI,levelI;
+
+  gips[2].xCmpntRay = fracA*gips[iB].xCmpntRay + fracB*gips[iA].xCmpntRay; /* This does not seem to be used. */
+
+  for(di=0;di<DIM;di++){
+    gips[2].x[di] = fracA*gips[iB].x[di] + fracB*gips[iA].x[di];
+  }
+  for(di=0;di<3;di++){ /* 3 not DIM, because a B field only makes sense in 3 dimensions. */
+    gips[2].B[di] = fracA*gips[iB].B[di] + fracB*gips[iA].B[di];
+  }
+
+  for(molI=0;molI<numMols;molI++){
+    gips[2].mol[molI].binv = fracA*gips[iB].mol[molI].binv + fracB*gips[iA].mol[molI].binv;
+
+    for(levelI=0;levelI<md[molI].nlev;levelI++){
+      gips[2].mol[molI].specNumDens[levelI] = fracA*gips[iB].mol[molI].specNumDens[levelI]\
+                                            + fracB*gips[iA].mol[molI].specNumDens[levelI];
+    }
+  }
+
+  gips[2].cont.dust = fracA*gips[iB].cont.dust + fracB*gips[iA].cont.dust;
+  gips[2].cont.knu  = fracA*gips[iB].cont.knu  + fracB*gips[iA].cont.knu;
+}
+
+/*....................................................................*/
 void traceray_smooth(rayData ray, const double local_cmb, const int im\
-  , configInfo *par, struct grid *gp, molData *md, image *img\
-  , struct cell *dc, const unsigned long numCells, const double epsilon\
+  , configInfo *par, struct grid *gp, double *vertexCoords, molData *md, image *img\
+  , struct simplex *dc, const unsigned long numCells, const double epsilon\
   , gridInterp gips[3], const int numSegments, const double oneOnNumSegments\
   , const int nSteps, const double oneOnNSteps){
   /*
@@ -297,7 +376,7 @@ This version of traceray implements a new algorithm in which the population valu
 
   /* Find the chain of cells the ray passes through.
   */
-  status = followRayThroughDelCells(x, dir, gp, dc, numCells, epsilon\
+  status = followRayThroughCells(x, dir, vertexCoords, dc, numCells, epsilon\
     , &entryIntcptFirstCell, &chainOfCellIds, &cellExitIntcpts, &lenChainPtrs);
 
   if(status!=0){
@@ -315,7 +394,7 @@ This version of traceray implements a new algorithm in which the population valu
   vvi = 0;
   for(vi=0;vi<numFaces;vi++){
     if(vi!=entryIntcptFirstCell.fi){
-      gis[entryI][vvi++] = dc[dci].vertx[vi]->id;
+      gis[entryI][vvi++] = dc[dci].vertx[vi];
     }
   }
 
@@ -337,7 +416,7 @@ This version of traceray implements a new algorithm in which the population valu
     vvi = 0;
     for(vi=0;vi<numFaces;vi++){
       if(vi!=cellExitIntcpts[ci].fi){
-        gis[exitI][vvi++] = dc[dci].vertx[vi]->id;
+        gis[exitI][vvi++] = dc[dci].vertx[vi];
       }
     }
 
@@ -460,7 +539,10 @@ At the moment I will fix the number of segments, but it might possibly be faster
 }
 
 /*....................................................................*/
-void locateRayOnImage(double x[2], const double size, const double imgCentreXPixels, const double imgCentreYPixels, image *img, const int im, const int maxNumRaysPerPixel, rayData *rays, int *numActiveRays){
+void locateRayOnImage(double x[2], const double size\
+  , const double imgCentreXPixels, const double imgCentreYPixels, image *img\
+  , const int im, const int maxNumRaysPerPixel, rayData *rays, int *numActiveRays){
+
   int xi,yi,ichan;
   _Bool isOutsideImage;
   unsigned int ppi;
@@ -498,6 +580,87 @@ void locateRayOnImage(double x[2], const double size, const double imgCentreXPix
 }
 
 /*....................................................................*/
+void calcTriangleBaryCoords(double vertices[3][2], double x, double y, double barys[3]){
+  double mat[2][2], vec[2], det;
+  /*
+The barycentric coordinates (L0,L1,L2) of a point r[] in a triangle v[] are given by
+
+	(v[0][0]-v[2][0]  v[1][0]-v[2][0]) (L0)   (r[0]-v[2][0])
+	(                                )*(  ) = (            ),
+	(v[0][1]-v[2][1]  v[1][1]-v[2][1]) (L1)   (r[1]-v[2][1])
+
+with L2 = 1 - L0 - L1.
+  */
+  mat[0][0] = vertices[0][0] - vertices[2][0];
+  mat[0][1] = vertices[1][0] - vertices[2][0];
+  mat[1][0] = vertices[0][1] - vertices[2][1];
+  mat[1][1] = vertices[1][1] - vertices[2][1];
+  vec[0] = x - vertices[2][0];
+  vec[1] = y - vertices[2][1];
+  det = mat[0][0]*mat[1][1] - mat[0][1]*mat[1][0];
+  /*** We're assuming that the triangle is not pathological, i.e that det!=0. */
+  barys[0] = ( mat[1][1]*vec[0] - mat[0][1]*vec[1])/det;
+  barys[1] = (-mat[1][0]*vec[0] + mat[0][0]*vec[1])/det;
+  barys[2] = 1.0 - barys[0] - barys[1];
+}
+
+/*....................................................................*/
+double *
+extractGridXs(const unsigned short numDims, const unsigned long numPoints\
+  , struct grid *gp){
+
+  double *xValues=NULL;
+  unsigned long i_ul;
+  unsigned short i_us;
+
+  xValues = malloc(sizeof(*xValues)*numDims*numPoints);
+  for(i_ul=0;i_ul<numPoints;i_ul++){
+    for(i_us=0;i_us<numDims;i_us++)
+      xValues[numDims*i_ul+i_us] = gp[i_ul].x[i_us];
+  }
+
+  return xValues;
+}
+
+/*....................................................................*/
+struct simplex *
+convertCellType(const unsigned short numDims, const unsigned long numCells\
+  , struct cell *dc, struct grid *gp){
+
+  struct simplex *cells=NULL;
+  unsigned long dci,gi;
+  unsigned short vi,di;
+
+  cells = malloc(sizeof(*cells)*numCells);
+  for(dci=0;dci<numCells;dci++){
+    cells[dci].id = dci;
+
+    for(vi=0;vi<numDims+1;vi++)
+      cells[dci].vertx[vi] = dc[dci].vertx[vi]->id;
+
+    for(di=0;di<numDims;di++)
+      cells[dci].centre[di] = 0.0;
+    for(vi=0;vi<numDims+1;vi++){
+      gi = cells[dci].vertx[vi];
+      for(di=0;di<numDims;di++)
+        cells[dci].centre[di] += gp[gi].x[di];
+    }
+    for(di=0;di<numDims;di++)
+      cells[dci].centre[di] *= (1.0/(double)(numDims+1));
+  }
+  for(dci=0;dci<numCells;dci++){
+    for(vi=0;vi<numDims+1;vi++){
+      if(dc[dci].neigh[vi]==NULL)
+        cells[dci].neigh[vi] = NULL;
+      else
+        cells[dci].neigh[vi] = &cells[dc[dci].neigh[vi]->id];
+    }
+  }
+
+  return cells;
+}
+
+/*....................................................................*/
 void
 raytrace(int im, configInfo *par, struct grid *gp, molData *md, image *img, double *lamtab, double *kaptab, const int nEntries){
   /*
@@ -520,6 +683,7 @@ Note that the argument 'md', and the grid element '.mol', are only accessed for 
   int cmbMolI,cmbLineI;
   rayData *rays;
   struct cell *dc=NULL;
+  struct simplex *cells=NULL;
   unsigned long numCells,dci;
   coordT *pt_array, point[3];
   char flags[255];
@@ -529,7 +693,7 @@ Note that the argument 'md', and the grid element '.mol', are only accessed for 
   vertexT *vertex,**vertexp;
   int curlong, totlong;
   double triangle[3][2],barys[3],local_cmb,cmbFreq,circleSpacing,scale,angle;
-  double *xySquared=NULL;
+  double *xySquared=NULL,*vertexCoords=NULL;
   gsl_error_handler_t *defaultErrorHandler=NULL;
 
   size = img[im].distance*img[im].imgres;
@@ -640,6 +804,7 @@ How to calculate this distance? Well if we have N points randomly but evenly dis
 
   if(par->traceRayAlgorithm==1){
     delaunay(DIM, gp, (unsigned long)par->ncell, 1, &dc, &numCells); /* mallocs dc if getCells==T */
+//**** Actually we can figure out the cell geometry from the grid neighbours.
 
     /* We need to process the list of cells a bit further - calculate their centres, and reset the id values to be the same as the index of the cell in the list. (This last because we are going to construct other lists to indicate which cells have been visited etc.)
     */
@@ -654,6 +819,10 @@ How to calculate this distance? Well if we have N points randomly but evenly dis
 
       dc[dci].id = dci;
     }
+
+    vertexCoords = extractGridXs(DIM, (unsigned long)par->ncell, gp);
+    cells = convertCellType(DIM, numCells, dc, gp);
+    free(dc);
 
   }else if(par->traceRayAlgorithm!=0){
     if(!silent) bail_out("Unrecognized value of par.traceRayAlgorithm");
@@ -705,8 +874,8 @@ While this is off however, gsl_* calls will not exit if they encounter a problem
           , cutoff, nStepsThruCell, oneOnNSteps);
 
       else if(par->traceRayAlgorithm==1)
-        traceray_smooth(rays[ri], local_cmb, im, par, gp, md, img\
-          , dc, numCells, epsilon, gips\
+        traceray_smooth(rays[ri], local_cmb, im, par, gp, vertexCoords, md, img\
+          , cells, numCells, epsilon, gips\
           , numSegments, oneOnNumSegments, nStepsThruCell, oneOnNSteps);
 
       if (threadI == 0){ /* i.e., is master thread */
@@ -812,37 +981,14 @@ While this is off however, gsl_* calls will not exit if they encounter a problem
   } /* end if(numPixelsForInterp>0) */
 
   free(xySquared);
-  if(par->traceRayAlgorithm==1)
-    free(dc);
+  if(par->traceRayAlgorithm==1){
+    free(cells);
+    free(vertexCoords);
+  }
   for(ri=0;ri<numActiveRays;ri++){
     free(rays[ri].tau);
     free(rays[ri].intensity);
   }
   free(rays);
-}
-
-/*....................................................................*/
-void calcTriangleBaryCoords(double vertices[3][2], double x, double y, double barys[3]){
-  double mat[2][2], vec[2], det;
-  /*
-The barycentric coordinates (L0,L1,L2) of a point r[] in a triangle v[] are given by
-
-	(v[0][0]-v[2][0]  v[1][0]-v[2][0]) (L0)   (r[0]-v[2][0])
-	(                                )*(  ) = (            ),
-	(v[0][1]-v[2][1]  v[1][1]-v[2][1]) (L1)   (r[1]-v[2][1])
-
-with L2 = 1 - L0 - L1.
-  */
-  mat[0][0] = vertices[0][0] - vertices[2][0];
-  mat[0][1] = vertices[1][0] - vertices[2][0];
-  mat[1][0] = vertices[0][1] - vertices[2][1];
-  mat[1][1] = vertices[1][1] - vertices[2][1];
-  vec[0] = x - vertices[2][0];
-  vec[1] = y - vertices[2][1];
-  det = mat[0][0]*mat[1][1] - mat[0][1]*mat[1][0];
-  /*** We're assuming that the triangle is not pathological, i.e that det!=0. */
-  barys[0] = ( mat[1][1]*vec[0] - mat[0][1]*vec[1])/det;
-  barys[1] = (-mat[1][0]*vec[0] + mat[0][0]*vec[1])/det;
-  barys[2] = 1.0 - barys[0] - barys[1];
 }
 


### PR DESCRIPTION
I have made the raythrucells algorithm generic (i.e. no longer hard-wired to DIM==3), and the main reason for doing this (apart from promoting those noble software goals, elegance and robustness) was to allow the same code to be used in the dims==2 situation of following image raster lines through the 2D projected cells in raytrace(), which I had hoped would address #162. However I have just this instant realized that I have shot myself in foot here because I have arranged matters such that the number of dimensions is set via a macro in the new header file dims.h. Since I have made use of structs with array members with sizes set by DIM, which I did because it saves an awful lot of mallocing, I cannot of course also use them in the same executable for dims==2. So cut-and-paste in here whatever swearing you deem appropriate. I will have to think about this some more. In itself it is a reasonable (if slightly sterile) PR but it doesn't advance towards solving #162.