### PR TITLE
Remove all but user-settable values from struct image.

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -15,8 +15,39 @@ TODO:
 #include <float.h>
 
 
+/*....................................................................*/
 void
-parseInput(inputPars inpar, configInfo *par, image **img, molData **m){
+mallocInputPars(inputPars *par){
+  int i;
+
+  par->moldatfile = malloc(sizeof(char *)*MAX_NSPECIES);
+
+  par->collPartIds  = malloc(sizeof(int)*MAX_N_COLL_PART);
+  for(i=0;i<MAX_N_COLL_PART;i++) par->collPartIds[i] = 0;
+  par->nMolWeights  = malloc(sizeof(double)*MAX_N_COLL_PART);
+  for(i=0;i<MAX_N_COLL_PART;i++) par->nMolWeights[i] = -1.0;
+  par->dustWeights  = malloc(sizeof(double)*MAX_N_COLL_PART);
+  for(i=0;i<MAX_N_COLL_PART;i++) par->dustWeights[i] = -1.0;
+}
+
+/*....................................................................*/
+void
+copyInparStr(const char *inStr, char **outStr){
+  if(inStr==NULL || strlen(inStr)<=0 || strlen(inStr)>STR_LEN_0){
+    *outStr = NULL;
+  }else{
+    *outStr = malloc(sizeof(**outStr)*(STR_LEN_0+1));
+    strcpy(*outStr, inStr);
+  }
+}
+
+/*....................................................................*/
+void
+parseInput(const inputPars inpar, image *inimg, const int nImages, configInfo *par, imageInfo **img, molData **md){
+  /*
+The parameters visible to the user have now been strictly confined to members of the structs 'inputPars' and 'image', both of which are defined in inpars.h. There are however further internally-set values which is is convenient to bundle together with the user-set ones. At present we have a fairly clunky arrangement in which the user-set values are copied member-by-member from the user-dedicated structs to the generic internal structs 'configInfo' and 'imageInfo'. This is done in the present function, along with some checks and other initialization.
+  */
+
   int i,j,id;
   double BB[3],normBSquared,dens[MAX_N_COLL_PART],r[DIM];
   double dummyVel[DIM];
@@ -27,7 +58,26 @@ parseInput(inputPars inpar, configInfo *par, image **img, molData **m){
   double tempRotMat[3][3],auxRotMat[3][3];
   int row,col;
 
-  /* Copy over user-set parameters to the configInfo versions. (This seems like duplicated effort but it is a good principle to separate the two structs, for several reasons, as follows. (i) We will usually want more config parameters than user-settable ones. The separation leaves it clearer which things the user needs to (or can) set. (ii) The separation allows checking and screening out of impossible combinations of parameters. (iii) We can adopt new names (for clarity) for config parameters without bothering the user with a changed interface.) */
+  /* Check that the mandatory parameters now have 'sensible' settings (i.e., that they have been set at all). Raise an exception if not. */
+  if (inpar.radius<=0){
+    if(!silent) bail_out("You must define the radius parameter.");
+    exit(1);
+  }
+  if (inpar.minScale<=0){
+    if(!silent) bail_out("You must define the minScale parameter.");
+    exit(1);
+  }
+  if (inpar.pIntensity<=0){
+    if(!silent) bail_out("You must define the pIntensity parameter.");
+    exit(1);
+  }
+  if (inpar.sinkPoints<=0){
+    if(!silent) bail_out("You must define the sinkPoints parameter.");
+    exit(1);
+  }
+
+  /* Copy over user-set parameters to the configInfo versions. (This seems like duplicated effort but it is a good principle to separate the two structs, for several reasons, as follows. (i) We will usually want more config parameters than user-settable ones. The separation leaves it clearer which things the user needs to (or can) set. (ii) The separation allows checking and screening out of impossible combinations of parameters. (iii) We can adopt new names (for clarity) for config parameters without bothering the user with a changed interface.)
+  */
   par->radius       = inpar.radius;
   par->minScale     = inpar.minScale;
   par->pIntensity   = inpar.pIntensity;
@@ -35,25 +85,28 @@ parseInput(inputPars inpar, configInfo *par, image **img, molData **m){
   par->samplingAlgorithm=inpar.samplingAlgorithm;
   par->sampling     = inpar.sampling;
   par->tcmb         = inpar.tcmb;
-  par->dust         = inpar.dust;
-  par->outputfile   = inpar.outputfile;
-  par->binoutputfile= inpar.binoutputfile;
-  par->restart      = inpar.restart;
-  par->gridfile     = inpar.gridfile;
-  par->pregrid      = inpar.pregrid;
   par->lte_only     = inpar.lte_only;
   par->init_lte     = inpar.init_lte;
   par->blend        = inpar.blend;
   par->antialias    = inpar.antialias;
   par->polarization = inpar.polarization;
   par->nThreads     = inpar.nThreads;
-  par->gridInFile   = inpar.gridInFile;
   par->nSolveIters  = inpar.nSolveIters;
   par->traceRayAlgorithm = inpar.traceRayAlgorithm;
 
+  /* Somewhat more carefully copy over the strings:
+  */
+  copyInparStr(inpar.dust,          &(par->dust));
+  copyInparStr(inpar.outputfile,    &(par->outputfile));
+  copyInparStr(inpar.binoutputfile, &(par->binoutputfile));
+  copyInparStr(inpar.restart,       &(par->restart));
+  copyInparStr(inpar.gridfile,      &(par->gridfile));
+  copyInparStr(inpar.pregrid,       &(par->pregrid));
+  copyInparStr(inpar.gridInFile,    &(par->gridInFile));
+
   par->gridOutFiles = malloc(sizeof(char *)*NUM_GRID_STAGES);
   for(i=0;i<NUM_GRID_STAGES;i++)
-    par->gridOutFiles[i] = inpar.gridOutFiles[i];
+    copyInparStr(inpar.gridOutFiles[i], &(par->gridOutFiles[i]));
 
   /* Now set the additional values in par. */
   par->ncell = inpar.pIntensity + inpar.sinkPoints;
@@ -68,20 +121,19 @@ parseInput(inputPars inpar, configInfo *par, image **img, molData **m){
   /* If the user has provided a list of moldatfile names, the corresponding elements of par->moldatfile will be non-NULL. Thus we can deduce the number of files (species) from the number of non-NULL elements.
   */
   par->nSpecies=0;
-  while(inpar.moldatfile[par->nSpecies]!=NULL && par->nSpecies<MAX_NSPECIES)
+  while(par->nSpecies<MAX_NSPECIES && inpar.moldatfile[par->nSpecies]!=NULL && strlen(inpar.moldatfile[par->nSpecies])>0)
     par->nSpecies++;
 
   /* Copy over the moldatfiles.
   */
   if(par->nSpecies == 0){
-    par->nSpecies = 1;
+    par->nSpecies = 1;/* ******************* should not confuse continuum and line in this way. */
     par->moldatfile = NULL;
 
   } else {
     par->moldatfile=malloc(sizeof(char *)*par->nSpecies);
-    for(id=0;id<par->nSpecies;id++){
-      par->moldatfile[id] = inpar.moldatfile[id];
-    }
+    for(id=0;id<par->nSpecies;id++)
+      copyInparStr(inpar.moldatfile[id], &(par->moldatfile[id]));
 
     /* Check if files exist. */
     for(id=0;id<par->nSpecies;id++){
@@ -152,12 +204,6 @@ parseInput(inputPars inpar, configInfo *par, image **img, molData **m){
     exit(1);
   }
 
-  /* If the user has provided a list of image filenames, the corresponding elements of (*img).filename will be non-NULL. Thus we can deduce the number of images from the number of non-NULL elements.
-  */
-  par->nImages=0;
-  while((*img)[par->nImages].filename!=NULL && par->nImages<MAX_NIMAGES)
-    par->nImages++;
-
   for(i=0;i<NUM_GRID_STAGES;i++){
     if(par->gridOutFiles[i] != NULL)
       par->writeGridAtStage[i] = 1;
@@ -178,11 +224,35 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
 
   */
   par->taylorCutoff = pow(24.*DBL_EPSILON, 0.25);
-
+  par->nImages = nImages;
   par->numDims = DIM;
 
-  /* Allocate pixel space and parse image information */
-  for(i=0;i<par->nImages;i++){
+  /* Copy over user-set image values to the generic struct:
+  */
+  *img = malloc(sizeof(**img)*nImages);
+  for(i=0;i<nImages;i++){
+    (*img)[i].nchan      = inimg[i].nchan;
+    (*img)[i].trans      = inimg[i].trans;
+    (*img)[i].molI       = inimg[i].molI;
+    (*img)[i].velres     = inimg[i].velres;
+    (*img)[i].imgres     = inimg[i].imgres;
+    (*img)[i].pxls       = inimg[i].pxls;
+    (*img)[i].unit       = inimg[i].unit;
+    (*img)[i].freq       = inimg[i].freq;
+    (*img)[i].bandwidth  = inimg[i].bandwidth;
+    copyInparStr(inimg[i].filename, &((*img)[i].filename));
+    (*img)[i].source_vel = inimg[i].source_vel;
+    (*img)[i].theta      = inimg[i].theta;
+    (*img)[i].phi        = inimg[i].phi;
+    (*img)[i].incl       = inimg[i].incl;
+    (*img)[i].posang     = inimg[i].posang;
+    (*img)[i].azimuth    = inimg[i].azimuth;
+    (*img)[i].distance   = inimg[i].distance;
+  }
+
+  /* Allocate pixel space and parse image information.
+  */
+  for(i=0;i<nImages;i++){
     if((*img)[i].nchan == 0 && (*img)[i].velres<0 ){ /* => user has set neither nchan nor velres. One of the two is required for a line image. */
       /* Assume continuum image */
 
@@ -418,7 +488,7 @@ LIME provides two different schemes of {R_1, R_2, R_3}: {PA, phi, theta} and {PA
 
   par->nLineImages = 0;
   par->nContImages = 0;
-  for(i=0;i<par->nImages;i++){
+  for(i=0;i<nImages;i++){
     if((*img)[i].doline)
       par->nLineImages++;
     else
@@ -427,18 +497,18 @@ LIME provides two different schemes of {R_1, R_2, R_3}: {PA, phi, theta} and {PA
 
   /* Allocate moldata array.
   */
-  (*m)=malloc(sizeof(molData)*par->nSpecies);
+  (*md)=malloc(sizeof(molData)*par->nSpecies);
   for( i=0; i<par->nSpecies; i++ ){
-    (*m)[i].part = NULL;
-    (*m)[i].lal = NULL;
-    (*m)[i].lau = NULL;
-    (*m)[i].aeinst = NULL;
-    (*m)[i].freq = NULL;
-    (*m)[i].beinstu = NULL;
-    (*m)[i].beinstl = NULL;
-    (*m)[i].eterm = NULL;
-    (*m)[i].gstat = NULL;
-    (*m)[i].cmb = NULL;
+    (*md)[i].part = NULL;
+    (*md)[i].lal = NULL;
+    (*md)[i].lau = NULL;
+    (*md)[i].aeinst = NULL;
+    (*md)[i].freq = NULL;
+    (*md)[i].beinstu = NULL;
+    (*md)[i].beinstl = NULL;
+    (*md)[i].eterm = NULL;
+    (*md)[i].gstat = NULL;
+    (*md)[i].cmb = NULL;
   }
 }
 

--- a/src/frees.c
+++ b/src/frees.c
@@ -9,13 +9,25 @@
 
 #include "lime.h"
 
-void freeConfig(configInfo par){
-  free(par.moldatfile);
-  free(par.collPartIds);
+void
+freeConfigInfo(configInfo par){
+  int i;
+
   free(par.nMolWeights);
   free(par.dustWeights);
-  free(par.gridDensMaxLoc);
-  free(par.gridDensMaxValues);
+  free(par.collPartIds);
+
+  free(par.outputfile);
+  free(par.binoutputfile);
+  free(par.gridfile);
+  free(par.pregrid);
+  free(par.restart);
+  free(par.dust);
+  if(par.moldatfile!= NULL){
+    for(i=0;i<par.nSpecies;i++)
+      free(par.moldatfile[i]);
+    free(par.moldatfile);
+  }
 }
 
 void freeGrid(const unsigned int numPoints, const unsigned short numSpecies\
@@ -52,6 +64,20 @@ freeGridPointData(configInfo *par, gridPointData *mol){
     }
     free(mol);
   }
+}
+
+void
+freeImgInfo(const int nImages, imageInfo *img){
+  int i,id;
+  for(i=0;i<nImages;i++){
+    for(id=0;id<(img[i].pxls*img[i].pxls);id++){
+      free( img[i].pixel[id].intense );
+      free( img[i].pixel[id].tau );
+    }
+    free(img[i].pixel);
+    free(img[i].filename);
+  }
+  free(img);
 }
 
 void
@@ -95,30 +121,6 @@ void freeMolsWithBlends(struct molWithBlends *mols, const int numMolsWithBlends)
     }
     free(mols);
   }
-}
-
-void
-freeParImg(const int nImages, inputPars *par, image *img){
-  /* Release memory allocated for the output fits images
-     and for inputPars pointers.
-  */
-  int i,id;
-  for(i=0;i<nImages;i++){
-    for(id=0;id<(img[i].pxls*img[i].pxls);id++){
-      free( img[i].pixel[id].intense );
-      free( img[i].pixel[id].tau );
-    }
-    free(img[i].pixel);
-  }
-  free(img);
-
-  free(par->gridDensMaxValues);
-  free(par->gridDensMaxLoc);
-  free(par->moldatfile);
-  free(par->collPartIds);
-  free(par->nMolWeights);
-  free(par->dustWeights);
-  free(par->gridOutFiles);
 }
 
 void freePopulation(const unsigned short numSpecies, struct populations *pop){

--- a/src/grid.c
+++ b/src/grid.c
@@ -179,7 +179,7 @@ void calcGridContDustOpacity(configInfo *par, const double freq\
     gasIIdust(gp[id].x[0],gp[id].x[1],gp[id].x[2],&gtd);
     gp[id].cont.knu = kappa*2.4*AMU*densityForDust/gtd;
     /* Check if input model supplies a dust temperature. Otherwise use the kinetic temperature. */
-    if(gp[id].t[1]==-1) {
+    if(gp[id].t[1]<=0.0) { /* Flags that the user has not set it. */
       gp[id].cont.dust = planckfunc(freq,gp[id].t[0]);
     } else {
       gp[id].cont.dust = planckfunc(freq,gp[id].t[1]);
@@ -236,9 +236,9 @@ void calcGridLinesDustOpacity(configInfo *par, molData *md, double *lamtab\
       for(iline=0;iline<md[si].nline;iline++){
         gp[id].mol[si].cont[iline].knu = kappatab[iline]*dustToGas;
         /* Check if input model supplies a dust temperature. Otherwise use the kinetic temperature. */
-        if(gp[id].t[1]==-1)
+        if(gp[id].t[1]<=0.0){ /* Flags that the user has not set it. */
           t = gp[id].t[0];
-        else
+        }else
           t = gp[id].t[1];
         gp[id].mol[si].cont[iline].dust = planckfunc(md[si].freq[iline],t);
       }

--- a/src/inpars.h
+++ b/src/inpars.h
@@ -27,4 +27,18 @@ typedef struct {
   double (*gridDensMaxLoc)[DIM], *gridDensMaxValues;
 } inputPars;
 
+/* Image information */
+typedef struct {
+  int nchan,trans,molI;
+  double velres;
+  double imgres;
+  int pxls;
+  int unit;
+  double freq,bandwidth;
+  char *filename;
+  double source_vel;
+  double theta,phi,incl,posang,azimuth;
+  double distance;
+} image;
+
 #endif /* INPARS_H */

--- a/src/lime.h
+++ b/src/lime.h
@@ -88,6 +88,7 @@
 #define MAX_N_COLL_PART		7
 #define N_SMOOTH_ITERS          20
 #define TYPICAL_ISM_DENS        1000.0
+#define STR_LEN_0               80
 #define DENSITY_POWER		0.2
 #define MAX_N_HIGH              10
 #define TREE_POWER		2.0
@@ -246,7 +247,7 @@ typedef struct {
   double theta,phi,incl,posang,azimuth;
   double distance;
   double rotMat[3][3];
-} image;
+} imageInfo;
 
 typedef struct {
   double x,y, *intensity, *tau;
@@ -318,7 +319,7 @@ void gasIIdust(double,double,double,double *);
 double gridDensity(configInfo*, double*);
 
 /* More functions */
-void	run(inputPars, image *);
+void	run(inputPars, image*, const int);
 
 _Bool	allBitsSet(const int flags, const int mask);
 _Bool	anyBitSet(const int flags, const int mask);
@@ -348,7 +349,6 @@ void	calcTriangleBaryCoords(double vertices[3][2], double, double, double barys[
 triangle2D calcTriangle2D(faceType);
 void	checkGridDensities(configInfo*, struct grid*);
 void	checkUserDensWeights(configInfo*);
-void	continuumSetup(int, image*, molData*, configInfo*, struct grid*);
 void	delaunay(const int, struct grid*, const unsigned long, const _Bool, struct cell**, unsigned long*);
 void	distCalc(configInfo*, struct grid*);
 void	doBaryInterp(const intersectType, struct grid*, double*, unsigned long*, molData*, const int, gridInterp*);
@@ -361,12 +361,12 @@ void	fit_d1fi(double, double, double*);
 void	fit_fi(double, double, double*);
 void	fit_rr(double, double, double*);
 int	followRayThroughDelCells(double*, double*, struct grid*, struct cell*, const unsigned long, const double, intersectType*, unsigned long**, intersectType**, int*);
-void	freeConfig(configInfo par);
+void	freeConfigInfo(configInfo par);
 void	freeGrid(const unsigned int, const unsigned short, struct grid*);
 void	freeGridPointData(configInfo*, gridPointData*);
+void	freeImgInfo(const int, imageInfo*);
 void	freeMolData(const int, molData*);
 void	freeMolsWithBlends(struct molWithBlends*, const int);
-void	freeParImg(const int, inputPars*, image*);
 void	freePopulation(const unsigned short, struct populations*);
 void	freeSomeGridFields(const unsigned int, const unsigned short, struct grid*);
 double  gaussline(const double, const double);
@@ -391,9 +391,10 @@ void	lineBlend(molData*, configInfo*, struct blendInfo*);
 void	LTE(configInfo*, struct grid*, molData*);
 void	lteOnePoint(molData*, const int, const double, double*);
 void	mallocAndSetDefaultGrid(struct grid**, const unsigned int);
+void	mallocInputPars(inputPars*);
 void	molInit(configInfo*, molData*);
 void	openSocket(char*);
-void	parseInput(inputPars, configInfo*, image**, molData**);
+void	parseInput(inputPars, image*, const int, configInfo*, imageInfo**, molData**);
 void	photon(int, struct grid*, molData*, int, const gsl_rng*, configInfo*, const int, struct blendInfo, gridPointData*, double*);
 double	planckfunc(const double, const double);
 int	pointEvaluation(configInfo*, const double, double*);
@@ -402,14 +403,14 @@ void	popsout(configInfo*, struct grid*, molData*);
 void	predefinedGrid(configInfo*, struct grid*);
 void	processFitsError(int);
 double	ratranInput(char*, char*, double, double, double);
-void	raytrace(int, configInfo*, struct grid*, molData*, image*, double*, double*, const int);
+void	raytrace(int, configInfo*, struct grid*, molData*, imageInfo*, double*, double*, const int);
 void	readDummyCollPart(FILE*, const int);
 void	readDustFile(char*, double**, double**, int*);
 void	readMolData(configInfo*, molData*, int**, int*);
 void	readOrBuildGrid(configInfo*, struct grid**);
-void	readUserInput(inputPars*, image**, int*, int*);
+void	readUserInput(inputPars*, imageInfo**, int*, int*);
 void	report(int, configInfo*, struct grid*);
-void	setUpConfig(configInfo*, image**, molData**);
+void	setUpConfig(configInfo*, imageInfo**, molData**);
 void	setUpDensityAux(configInfo*, int*, const int);
 void	smooth(configInfo*, struct grid*);
 void    sourceFunc_line(const molData*, const double, const struct populations*, const int, double*, double*);
@@ -419,12 +420,12 @@ void	stateq(int, struct grid*, molData*, const int, configInfo*, struct blendInf
 void	statistics(int, molData*, struct grid*, int*, double*, double*, int*);
 void	stokesangles(double*, double (*rotMat)[3], double*);
 double	taylor(const int, const float);
-void	traceray(rayData, const double, const int, configInfo*, struct grid*, molData*, image*, const double, const int, const double);
-void	traceray_smooth(rayData, const double, const int, configInfo*, struct grid*, molData*, image*, struct cell*, const unsigned long, const double, gridInterp gips[3], const int, const double, const int, const double);
+void	traceray(rayData, const double, const int, configInfo*, struct grid*, molData*, imageInfo*, const double, const int, const double);
+void	traceray_smooth(rayData, const double, const int, configInfo*, struct grid*, molData*, imageInfo*, struct cell*, const unsigned long, const double, gridInterp gips[3], const int, const double, const int, const double);
 double	veloproject(const double*, const double*);
-void	write2Dfits(int, configInfo*, image*);
-void	write3Dfits(int, configInfo*, image*);
-void	writeFits(const int, configInfo*, image*);
+void	write2Dfits(int, configInfo*, imageInfo*);
+void	write3Dfits(int, configInfo*, imageInfo*);
+void	writeFits(const int, configInfo*, imageInfo*);
 void	writeGridIfRequired(configInfo*, struct grid*, molData*, const int);
 void	write_VTK_unstructured_Points(configInfo*, struct grid*);
 

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -91,7 +91,7 @@ This function returns ds as the (always positive-valued) distance between the pr
 
 /*....................................................................*/
 void traceray(rayData ray, const double local_cmb, const int im\
-  , configInfo *par, struct grid *gp, molData *md, image *img\
+  , configInfo *par, struct grid *gp, molData *md, imageInfo *img\
   , const double cutoff, const int nSteps, const double oneOnNSteps){
   /*
 For a given image pixel position, this function evaluates the intensity of the total light emitted/absorbed along that line of sight through the (possibly rotated) model. The calculation is performed for several frequencies, one per channel of the output image.
@@ -251,7 +251,7 @@ Note that the algorithm employed here is similar to that employed in the functio
 
 /*....................................................................*/
 void traceray_smooth(rayData ray, const double local_cmb, const int im\
-  , configInfo *par, struct grid *gp, molData *md, image *img\
+  , configInfo *par, struct grid *gp, molData *md, imageInfo *img\
   , struct cell *dc, const unsigned long numCells, const double epsilon\
   , gridInterp gips[3], const int numSegments, const double oneOnNumSegments\
   , const int nSteps, const double oneOnNSteps){
@@ -460,7 +460,7 @@ At the moment I will fix the number of segments, but it might possibly be faster
 }
 
 /*....................................................................*/
-void locateRayOnImage(double x[2], const double size, const double imgCentreXPixels, const double imgCentreYPixels, image *img, const int im, const int maxNumRaysPerPixel, rayData *rays, int *numActiveRays){
+void locateRayOnImage(double x[2], const double size, const double imgCentreXPixels, const double imgCentreYPixels, imageInfo *img, const int im, const int maxNumRaysPerPixel, rayData *rays, int *numActiveRays){
   int xi,yi,ichan;
   _Bool isOutsideImage;
   unsigned int ppi;
@@ -499,7 +499,8 @@ void locateRayOnImage(double x[2], const double size, const double imgCentreXPix
 
 /*....................................................................*/
 void
-raytrace(int im, configInfo *par, struct grid *gp, molData *md, image *img, double *lamtab, double *kaptab, const int nEntries){
+raytrace(int im, configInfo *par, struct grid *gp, molData *md\
+  , imageInfo *img, double *lamtab, double *kaptab, const int nEntries){
   /*
 This function constructs an image cube by following sets of rays (at least 1 per image pixel) through the model, solving the radiative transfer equations as appropriate for each ray. The ray locations within each pixel are chosen randomly within the pixel, but the number of rays per pixel is set equal to the number of projected model grid points falling within that pixel, down to a minimum equal to par->alias.
 

--- a/src/tcpsocket.c
+++ b/src/tcpsocket.c
@@ -28,14 +28,16 @@ openSocket(char *moldatfile){
   char *page = "~moldata/datafiles/";
   char *tpl= "GET /%s HTTP/1.0\r\nHost: %s\r\nUser-Agent: %s\r\n\r\n";
   FILE *fp;
+  char *suffix = ".dat";
+  const int lenSuffix = strlen(suffix);
 
   /* Check if moldatfile contains .dat */
-  if(strstr(moldatfile, ".dat") == NULL){
+  if(strstr(moldatfile, suffix) == NULL){
     size_t length = strlen(moldatfile);
-    s = (char*)malloc(sizeof(char) * (length + 5));
+    s = (char*)malloc(sizeof(char)*(length + lenSuffix + 1));
     strcpy(s,moldatfile);
-    strcat(s, ".dat");
-    s[length+5]='\0';
+    strcat(s, suffix);
+    s[length+lenSuffix]='\0';
     moldatfile=s;
   }
 

--- a/src/writefits.c
+++ b/src/writefits.c
@@ -9,7 +9,7 @@
 
 #include "lime.h"
 
-void writeFits(const int i, configInfo *par, image *img){
+void writeFits(const int i, configInfo *par, imageInfo *img){
   if(img[i].unit<5)
     write3Dfits(i,par,img);
   else if(img[i].unit==5)
@@ -21,7 +21,7 @@ void writeFits(const int i, configInfo *par, image *img){
 }
 
 void 
-write3Dfits(int im, configInfo *par, image *img){
+write3Dfits(int im, configInfo *par, imageInfo *img){
   double bscale,bzero,epoch,lonpole,equinox,restfreq;
   double cdelt1,crpix1,crval1,cdelt2,crpix2,crval2;
   double cdelt3,crpix3,crval3,ru3,scale;
@@ -150,7 +150,7 @@ write3Dfits(int im, configInfo *par, image *img){
 }
 
 void 
-write2Dfits(int im, configInfo *par, image *img){
+write2Dfits(int im, configInfo *par, imageInfo *img){
   double bscale,bzero,epoch,lonpole,equinox,restfreq;
   double cdelt1,crpix1,crval1,cdelt2,crpix2,crval2;
   double ru3,scale;


### PR DESCRIPTION
PR #77 did this for the inputPars. I am not sure why I did not also do the same job at that time on the user-settable image parameters, but I am doing so now.

The motivation for doing this is the same as for #77. An additional reason is that it allows easier integration of Lime into [Artist.](http://youngstars.nbi.dk/artist/Welcome.html)