### PR TITLE
Photon keeps near nominal track rather than to direction.

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -764,6 +764,7 @@ Pointers are indicated by a * before the attribute name and an arrow to the memo
   }
 }
 
+/*....................................................................*/
 void
 levelPops(molData *md, configInfo *par, struct grid *gp, int *popsdone, double *lamtab, double *kaptab, const int nEntries){
   int id,iter,ilev,ispec,c=0,n,i,threadI,nVerticesDone,nItersDone,nlinetot;//,conv=0

--- a/src/aux.c
+++ b/src/aux.c
@@ -16,6 +16,12 @@ TODO:
 
 
 /*....................................................................*/
+double
+dotProduct3D(const double *vA, const double *vB){
+  return vA[0]*vB[0] + vA[1]*vB[1] + vA[2]*vB[2];
+}
+
+/*....................................................................*/
 void
 mallocInputPars(inputPars *par){
   int i;
@@ -767,7 +773,7 @@ Pointers are indicated by a * before the attribute name and an arrow to the memo
 /*....................................................................*/
 void
 levelPops(molData *md, configInfo *par, struct grid *gp, int *popsdone, double *lamtab, double *kaptab, const int nEntries){
-  int id,iter,ilev,ispec,c=0,n,i,threadI,nVerticesDone,nItersDone,nlinetot;//,conv=0
+  int id,iter,ilev,ispec,c=0,n,i,threadI,nVerticesDone,nItersDone,nlinetot;
   double percent=0.,*median,result1=0,result2=0,snr,delta_pop;
   int nextMolWithBlend;
   struct statistics { double *pop, *ave, *sigma; } *stat;

--- a/src/lime.h
+++ b/src/lime.h
@@ -342,7 +342,6 @@ void	getclosest(double, double, double, long*, long*, double*, double*, double*)
 void	getjbar(int, molData*, struct grid*, const int, configInfo*, struct blendInfo, int, gridPointData*, double*);
 void	getMass(configInfo*, struct grid*, const gsl_rng*);
 void	getmatrix(int, gsl_matrix*, molData*, struct grid*, int, gridPointData*);
-int	getNextEdge(double*, int, struct grid*, const gsl_rng*);
 void	getVelocities(configInfo *, struct grid *);
 void	getVelocities_pregrid(configInfo *, struct grid *);
 void	gridPopsInit(configInfo*, molData*, struct grid*);

--- a/src/lime.h
+++ b/src/lime.h
@@ -322,6 +322,7 @@ void	checkGridDensities(configInfo*, struct grid*);
 void	checkUserDensWeights(configInfo*);
 void	delaunay(const int, struct grid*, const unsigned long, const _Bool, struct cell**, unsigned long*);
 void	distCalc(configInfo*, struct grid*);
+double	dotProduct3D(const double*, const double*);
 int	factorial(const int);
 double	FastExp(const float);
 void    fillErfTable();
@@ -382,7 +383,6 @@ void	stateq(int, struct grid*, molData*, const int, configInfo*, struct blendInf
 void	statistics(int, molData*, struct grid*, int*, double*, double*, int*);
 void	stokesangles(double*, double (*rotMat)[3], double*);
 double	taylor(const int, const float);
-double	veloproject(const double*, const double*);
 void	write2Dfits(int, configInfo*, imageInfo*);
 void	write3Dfits(int, configInfo*, imageInfo*);
 void	writeFits(const int, configInfo*, imageInfo*);

--- a/src/main.c
+++ b/src/main.c
@@ -168,7 +168,6 @@ run(inputPars inpars, image *inimg, const int nImages){
 #endif
   fillErfTable();
 
-//  par.nImages = nImages;
   parseInput(inpars, inimg, nImages, &par, &img, &md); /* Sets par.numDensities for !(par.doPregrid || par.restart) */
 
   if(!silent && par.nThreads>1){

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -26,7 +26,7 @@ The bulk velocity of the model material can vary significantly with position, th
 
   *vfac=0.;
   for(i=0;i<nSteps;i++){
-    v = deltav - projVels[i]; /* projVels contains the component of the local bulk velocity in the direction of dx, whereas deltav is the recession velocity of the channel we are interested in (corrected for bulk source velocity and line displacement from the nominal frequency). Remember also that, since dx points away from the observer, positive values of the projected velocity also represent recessions. Line centre occurs when v==0, i.e. when deltav==veloproject(dx,vel). That is the reason for the subtraction here. */
+    v = deltav - projVels[i]; /* projVels contains the component of the local bulk velocity in the direction of dx, whereas deltav is the recession velocity of the channel we are interested in (corrected for bulk source velocity and line displacement from the nominal frequency). Remember also that, since dx points away from the observer, positive values of the projected velocity also represent recessions. Line centre occurs when v==0, i.e. when deltav==dotProduct3D(dx,vel). That is the reason for the subtraction here. */
     val=fabs(v)*binv;
     if(val <=  2500.){
 #ifdef FASTEXP
@@ -168,7 +168,7 @@ Note that the algorithm employed here is similar to that employed in the functio
         for(i=0;i<nSteps;i++){
           d = i*ds*oneOnNSteps;
           velocity(x[0]+(dx[0]*d),x[1]+(dx[1]*d),x[2]+(dx[2]*d),vel);
-          projVels[i] = veloproject(dx,vel);
+          projVels[i] = dotProduct3D(dx,vel);
         }
       }
 
@@ -203,7 +203,7 @@ Note that the algorithm employed here is similar to that employed in the functio
                 if(!par->doPregrid)
                   calcLineAmpSample(x,dx,ds,gp[posn].mol[molI].binv,projVels,nSteps,oneOnNSteps,deltav,&vfac);
                 else
-                  vfac = gaussline(deltav-veloproject(dx,gp[posn].vel),gp[posn].mol[molI].binv);
+                  vfac = gaussline(deltav-dotProduct3D(dx,gp[posn].vel),gp[posn].mol[molI].binv);
 
                 /* Increment jnu and alpha for this Voronoi cell by the amounts appropriate to the spectral line. */
                 sourceFunc_line(&md[molI],vfac,&(gp[posn].mol[molI]),lineI,&jnu,&alpha);
@@ -402,7 +402,7 @@ This version of traceray implements a new algorithm in which the population valu
   /* Calculate, for each of the 3 vertices of the entry face, the displacement components in the direction of 'dir'. *** NOTE *** that if all the rays are parallel, we could precalculate these for all the vertices.
   */
   for(vi=0;vi<nVertPerFace;vi++)
-    xCmpntsRay[vi] = veloproject(dir, gp[gis[entryI][vi]].x);
+    xCmpntsRay[vi] = dotProduct3D(dir, gp[gis[entryI][vi]].x);
 
   doBaryInterp(entryIntcptFirstCell, gp, xCmpntsRay, gis[entryI]\
     , md, par->nSpecies, &gips[entryI]);
@@ -424,7 +424,7 @@ This version of traceray implements a new algorithm in which the population valu
     /* Calculate, for each of the 3 vertices of the exit face, the displacement components in the direction of 'dir'. *** NOTE *** that if all the rays are parallel, we could precalculate these for all the vertices.
     */
     for(vi=0;vi<nVertPerFace;vi++)
-      xCmpntsRay[vi] = veloproject(dir, gp[gis[exitI][vi]].x);
+      xCmpntsRay[vi] = dotProduct3D(dir, gp[gis[exitI][vi]].x);
 
     doBaryInterp(cellExitIntcpts[ci], gp, xCmpntsRay, gis[exitI]\
       , md, par->nSpecies, &gips[exitI]);
@@ -457,7 +457,7 @@ At the moment I will fix the number of segments, but it might possibly be faster
         /* It appears to be necessary to sample the velocity function in the following way rather than interpolating it from the vertices of the Delaunay cell in the same way as with all the other quantities of interest. Velocity varies too much across the cells, and in a nonlinear way, for linear interpolation to yield a totally satisfactory result.
         */
         velocity(gips[2].x[0], gips[2].x[1], gips[2].x[2], vel);
-        projVelRay = veloproject(dir, vel);
+        projVelRay = dotProduct3D(dir, vel);
 
         /* Calculate first the continuum stuff because it is the same for all channels:
         */


### PR DESCRIPTION
The function nextEdge() has been changed to prefer an edge which keeps the path through the model near the nominal track of the photon rather than an edge whose direction is as near as possible to the photon direction.

@tlunttil you are going to hate this because it runs 20% slower, throwing away all your nice speed gains.

I included a variant with some precalculation, which is faster, but still not as good as pre-PR.

Having written this thing I am starting to wonder how necessary it is! After all, the sampling of direction-frequency space is so sparse, perhaps it is not so important to reduce the fuzzy sampling of the model which the old algorithm implemented. This would probably only grow to importance if we implement adapative photon directions...

I also included a fix for #189.