### PR TITLE
Number of rays no longer scales with edges

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -847,9 +847,7 @@ While this is off however, other gsl_* etc calls will not exit if they encounter
           stat[id].pop[ilev+md[0].nlev*4]=gp[id].mol[0].pops[ilev];
         }
       }
-
       calcGridMolSpecNumDens(par,md,gp);
-
 
       nVerticesDone=0;
       omp_set_dynamic(0);
@@ -862,24 +860,25 @@ While this is off however, other gsl_* etc calls will not exit if they encounter
         gridPointData *mp;	// Could have declared them earlier
         double *halfFirstDs;	// and included them in private() I guess.
         mp=malloc(sizeof(gridPointData)*par->nSpecies);
-        for (ispec=0;ispec<par->nSpecies;ispec++){
-          mp[ispec].phot = malloc(sizeof(double)*md[ispec].nline*max_phot);
-          mp[ispec].vfac = malloc(sizeof(double)*               max_phot);
-          mp[ispec].vfac_loc = malloc(sizeof(double)*           max_phot);
-          mp[ispec].jbar = malloc(sizeof(double)*md[ispec].nline);
-        }
-        halfFirstDs = malloc(sizeof(*halfFirstDs)*max_phot);
 
 #pragma omp for schedule(dynamic)
         for(id=0;id<par->pIntensity;id++){
 #pragma omp atomic
           ++nVerticesDone;
 
+          for (ispec=0;ispec<par->nSpecies;ispec++){
+            mp[ispec].jbar = malloc(sizeof(double)*md[ispec].nline);
+            mp[ispec].phot = malloc(sizeof(double)*md[ispec].nline*gp[id].nphot);
+            mp[ispec].vfac = malloc(sizeof(double)*                gp[id].nphot);
+            mp[ispec].vfac_loc = malloc(sizeof(double)*            gp[id].nphot);
+          }
+          halfFirstDs = malloc(sizeof(*halfFirstDs)*gp[id].nphot);
+
           if (threadI == 0){ /* i.e., is master thread. */
             if(!silent) progressbar(nVerticesDone/(double)par->pIntensity,10);
           }
           if(gp[id].dens[0] > 0 && gp[id].t[0] > 0){
-            photon(id,gp,md,0,threadRans[threadI],par,nlinetot,blends,mp,halfFirstDs);
+            photon(id,gp,md,threadRans[threadI],par,nlinetot,blends,mp,halfFirstDs);
             nextMolWithBlend = 0;
             for(ispec=0;ispec<par->nSpecies;ispec++){
               stateq(id,gp,md,ispec,par,blends,nextMolWithBlend,mp,halfFirstDs,&luWarningGiven);
@@ -890,10 +889,10 @@ While this is off however, other gsl_* etc calls will not exit if they encounter
           if (threadI == 0){ /* i.e., is master thread */
             if(!silent) warning("");
           }
+          freeGridPointData(par->nSpecies, mp);
+          free(halfFirstDs);
         }
-
-        freeGridPointData(par, mp);
-        free(halfFirstDs);
+        free(mp);
       } /* end parallel block. */
 
       for(id=0;id<par->pIntensity;id++){

--- a/src/frees.c
+++ b/src/frees.c
@@ -54,16 +54,15 @@ freeGrid(const unsigned int numPoints, const unsigned short numSpecies\
 }
 
 void
-freeGridPointData(configInfo *par, gridPointData *mol){
+freeGridPointData(const int nSpecies, gridPointData *mol){
   int i;
   if(mol!= NULL){
-    for(i=0;i<par->nSpecies;i++){
+    for(i=0;i<nSpecies;i++){
       free(mol[i].jbar);
       free(mol[i].phot);
       free(mol[i].vfac);
       free(mol[i].vfac_loc);
     }
-    free(mol);
   }
 }
 

--- a/src/grid.c
+++ b/src/grid.c
@@ -461,13 +461,13 @@ void distCalc(configInfo *par, struct grid *gp){
     for(k=0;k<gp[i].numNeigh;k++){
       for(l=0;l<3;l++)
         gp[i].dir[k].x[l] = gp[i].neigh[k]->x[l] - gp[i].x[l];
-      gp[i].ds[k] = sqrt(  gp[i].dir[k].x[0]*gp[i].dir[k].x[0]\
+        gp[i].ds[k] = sqrt(  gp[i].dir[k].x[0]*gp[i].dir[k].x[0]\
                          + gp[i].dir[k].x[1]*gp[i].dir[k].x[1]\
                          + gp[i].dir[k].x[2]*gp[i].dir[k].x[2]);
       for(l=0;l<3;l++)
         gp[i].dir[k].xn[l] = gp[i].dir[k].x[l]/gp[i].ds[k];
     }
-    gp[i].nphot=ininphot*gp[i].numNeigh;
+    gp[i].nphot=RAYS_PER_POINT;
   }
 }
 
@@ -825,7 +825,7 @@ void randomsViaRejection(configInfo *par, const unsigned int desiredNumPoints, g
   }
 
   if(!silent && numSecondRandoms>0){
-    sprintf(errStr, ">1 random point needed for %d grid points out of %lu.", numSecondRandoms, desiredNumPoints);
+    sprintf(errStr, ">1 random point needed for %d grid points out of %u.", numSecondRandoms, desiredNumPoints);
     warning(errStr);
   }
 }

--- a/src/lime.h
+++ b/src/lime.h
@@ -70,8 +70,8 @@
 #define SPI                     1.77245385091		/* sqrt(pi)	*/
 #define maxp                    0.15
 #define NITERATIONS 		16
-#define max_phot                10000		/* don't set this value higher unless you have enough memory. */
-#define ininphot                9
+#define MAX_RAYS_PER_POINT      10000
+#define RAYS_PER_POINT		200
 #define minpop                  1.e-6
 #define eps                     1.0e-30
 #define TOL                     1e-6
@@ -330,7 +330,7 @@ void	fit_fi(double, double, double*);
 void	fit_rr(double, double, double*);
 void	freeConfigInfo(configInfo par);
 void	freeGrid(const unsigned int, const unsigned short, struct grid*);
-void	freeGridPointData(configInfo*, gridPointData*);
+void	freeGridPointData(const int, gridPointData*);
 void	freeImgInfo(const int, imageInfo*);
 void	freeMolData(const int, molData*);
 void	freeMolsWithBlends(struct molWithBlends*, const int);
@@ -358,7 +358,7 @@ void	mallocInputPars(inputPars*);
 void	molInit(configInfo*, molData*);
 void	openSocket(char*);
 void	parseInput(inputPars, image*, const int, configInfo*, imageInfo**, molData**);
-void	photon(int, struct grid*, molData*, int, const gsl_rng*, configInfo*, const int, struct blendInfo, gridPointData*, double*);
+void	photon(int, struct grid*, molData*, const gsl_rng*, configInfo*, const int, struct blendInfo, gridPointData*, double*);
 double	planckfunc(const double, const double);
 int	pointEvaluation(configInfo*, const double, double*);
 void	popsin(configInfo*, struct grid**, molData**, int*);

--- a/src/main.c
+++ b/src/main.c
@@ -227,12 +227,14 @@ run(inputPars inpars, image *inimg, const int nImages){
 
     calcGridMolSpecNumDens(&par,md,gp);
   }
-
+  /*
+  report(1,&par,gp);
+  */
   writeGridIfRequired(&par, gp, md, lime_FITS);
   freeSomeGridFields((unsigned int)par.ncell, (unsigned short)par.nSpecies, gp);
 
-  /* Now make the line images.
-  */
+  /* Now make the line images.   */
+
   if(par.nLineImages>0){
     for(i=0;i<par.nImages;i++){
       if(img[i].doline){

--- a/src/photon.c
+++ b/src/photon.c
@@ -197,18 +197,16 @@ void calcSourceFn(double dTau, const configInfo *par, double *remnantSnu, double
 
 /*....................................................................*/
 void
-photon(int id, struct grid *gp, molData *md, int iter, const gsl_rng *ran\
+photon(int id, struct grid *gp, molData *md, const gsl_rng *ran\
   , configInfo *par, const int nlinetot, struct blendInfo blends\
   , gridPointData *mp, double *halfFirstDs){
 
-  int iphot,iline,here,there,firststep,neighI,np_per_line,ip_at_line;
+  int iphot,iline,here,there,firststep,neighI;
   int nextMolWithBlend, nextLineWithBlend, molI, lineI, molJ, lineJ, bi;
   double segment,vblend_in,vblend_out,dtau,expDTau,ds_in=0.0,ds_out=0.0,pt_theta,pt_z,semiradius;
   double deltav[par->nSpecies],vfac_in[par->nSpecies],vfac_out[par->nSpecies],vfac_inprev[par->nSpecies];
   double expTau[nlinetot],inidir[3];
   double remnantSnu, velProj;
-
-  np_per_line=(int) gp[id].nphot/gp[id].numNeigh; // Works out to be equal to ininphot. :-/
 
   for(iphot=0;iphot<gp[id].nphot;iphot++){
     firststep=1;
@@ -232,15 +230,10 @@ photon(int id, struct grid *gp, molData *md, int iter, const gsl_rng *ran\
 
     /* Choose the photon frequency/velocity offset.
     */
-    iter=(int) (gsl_rng_uniform(ran)*(double)N_RAN_PER_SEGMENT); /* can have values in [0,1,..,N_RAN_PER_SEGMENT-1]*/
-    ip_at_line=(int) iphot/gp[id].numNeigh;
-    segment=(N_RAN_PER_SEGMENT*(ip_at_line-np_per_line*0.5)+iter)/(double)(np_per_line*N_RAN_PER_SEGMENT);
+    segment=gsl_rng_uniform(ran)-0.5;
     /*
     Values of segment should be evenly distributed (considering the
-    entire ensemble of photons) between -0.5 and +0.5, and are chosen
-    from a sequence of possible values separated by
-    1/(N_RAN_PER_SEGMENT*ininphot).
-
+    entire ensemble of photons) between -0.5 and +0.5.
     */
 
     for (molI=0;molI<par->nSpecies;molI++){

--- a/src/report.c
+++ b/src/report.c
@@ -14,57 +14,62 @@
 
 void
 report(int i, configInfo *par, struct grid *g){
-	FILE *fp;
-	int j,k,p,q;
-	const int bins = 100;
-	double x,min_l,max_l,min_p,max_p,min_p2,max_p2,r2;
+  FILE *fp;
+  int j,k,p,q,min_q,max_q;
+  const int bins = 100;
+  double x,min_l,max_l,min_p,max_p,min_p2,max_p2,r2;
   size_t n=bins;
   double hx[bins],hy[bins],hw[bins];
   double c0, c1, cov00, cov01, cov11, chisq1,b0, b1, chisq2;
 
   gsl_histogram * h = gsl_histogram_alloc (n);
   gsl_histogram * f = gsl_histogram_alloc (n);
-
-  fp=fopen("LimeReport","w");
-
+  
   if(i==1){
+    fp=fopen("LimeReport","w");
     fprintf(fp,"*** LIME report\n***\n");
     fprintf(fp,"*** Grid statistics\n\n");
 
-		j=0;
-		p=g[j].numNeigh;
-		q=g[j].nphot;
-		r2=g[j].x[0]*g[j].x[0]+g[j].x[1]*g[j].x[1]+g[j].x[2]*g[j].x[2];
-		min_p2=r2;
-		max_p2=r2;
-		k=0;
-		min_l=g[j].ds[k];
-		max_l=g[j].ds[k];
-		for(k=1;k<g[j].numNeigh;k++){
-			if(g[j].ds[k]<min_l) min_l=g[j].ds[k];
-			if(g[j].ds[k]>max_l) max_l=g[j].ds[k];
-		}
-		for(j=1;j<par->ncell;j++) {
+    j=0;
+    p=g[j].numNeigh;
+    q=g[j].nphot;
+    r2=g[j].x[0]*g[j].x[0]+g[j].x[1]*g[j].x[1]+g[j].x[2]*g[j].x[2];
+    min_p2=r2;
+    max_p2=r2;
+    k=0;
+    min_l=g[j].ds[k];
+    max_l=g[j].ds[k];
+    min_q=q;
+    max_q=q;
+    for(k=1;k<g[j].numNeigh;k++){
+      if(g[j].ds[k]<min_l) min_l=g[j].ds[k];
+      if(g[j].ds[k]>max_l) max_l=g[j].ds[k];
+    }
+    for(j=1;j<par->ncell;j++) {
       p+=g[j].numNeigh;
-      q+=g[j].nphot;
-			r2=g[j].x[0]*g[j].x[0]+g[j].x[1]*g[j].x[1]+g[j].x[2]*g[j].x[2];
-			if(r2<min_p2) min_p2=r2;
-			if(r2>max_p2) max_p2=r2;
+      if (!g[j].sink) {
+        q+=g[j].nphot;
+        if (g[j].nphot>max_q) max_q=g[j].nphot;
+        if (g[j].nphot<min_q) min_q=g[j].nphot;
+      }
+      r2=g[j].x[0]*g[j].x[0]+g[j].x[1]*g[j].x[1]+g[j].x[2]*g[j].x[2];
+      if(r2<min_p2) min_p2=r2;
+      if(r2>max_p2) max_p2=r2;
       for(k=0;k<g[j].numNeigh;k++){
         if(g[j].ds[k]<min_l) min_l=g[j].ds[k];
         if(g[j].ds[k]>max_l) max_l=g[j].ds[k];
       }
     }
-		min_p=sqrt(min_p2);
-		max_p=sqrt(max_p2);
+    min_p=sqrt(min_p2);
+    max_p=sqrt(max_p2);
     x=(double) p/par->ncell;
     p=p/2;
 
     gsl_histogram_set_ranges_uniform (h, par->minScale, par->radius);
     gsl_histogram_set_ranges_uniform (f, min_l, max_l);
 
-		for(j=0;j<par->ncell-par->sinkPoints;j++) {
-			gsl_histogram_increment (h, sqrt(g[j].x[0]*g[j].x[0]+g[j].x[1]*g[j].x[1]+g[j].x[2]*g[j].x[2])); 
+    for(j=0;j<par->ncell-par->sinkPoints;j++) {
+      gsl_histogram_increment (h, sqrt(g[j].x[0]*g[j].x[0]+g[j].x[1]*g[j].x[1]+g[j].x[2]*g[j].x[2])); 
       for(k=0;k<g[j].numNeigh;k++){
         gsl_histogram_increment (f, g[j].ds[k]);
       }
@@ -95,11 +100,11 @@ report(int i, configInfo *par, struct grid *g){
 
 
     fprintf(fp,"\n***\n*** Photon statistic\n\n");
-    fprintf(fp,"    Total photons   Average photons    Maximum photons\n");
-    fprintf(fp,"      %6d           %5d           %7d\n", q,q/(par->ncell-par->sinkPoints),max_phot);
+    fprintf(fp,"    Total photons   Average photons    Minimum photons  Maximum photons\n");
+    fprintf(fp,"      %6d           %5d                %7d              %7d\n", q,q/(par->ncell-par->sinkPoints),min_q,max_q);
+    fclose(fp);
   }
   /*    gsl_histogram_fprintf (stdout, h, "%g", "%g");	 */
 
   gsl_histogram_free (h);
-  fclose(fp);
 }

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -36,8 +36,8 @@ void statistics(int id, molData *m, struct grid *g, int *exceed, double *opops, 
     *conv+=1;
   }else {
     g[id].nphot=g[id].nphot+10;
-    if(g[id].nphot>(max_phot*200)){
-      g[id].nphot=max_phot*200;
+    if(g[id].nphot>(MAX_RAYS_PER_POINT)){
+      g[id].nphot=MAX_RAYS_PER_POINT;
       *exceed+=1;
       if(!silent) warning("Warning: limiting nphot reached in a grid point");
     }


### PR DESCRIPTION
The number of rays per grid point is now set by `RAYS_PER_POINT` in lime.h, currently set to 200. The number 200 is arbitrary, but the previous `ininphot 9` resulted in roughly similar (perhaps slightly smaller) number of rays on average.

Each grid point has (already had) an individual `nphot` attribute, which is currently set to `RAYS_PER_POINT` for every non-sink grid point. Currently that is not needed, but it can be useful later when adaptive ray sampling is implemented.

Sampling of frequencies was to some extent tied to the previous 'scale the number of rays according to edges' scheme. I didn't bother trying to recreate that, because the whole frequency integration part will probably be redone soon. Instead, I'm using a very simple uniform sampling, which is more of a place holder rather than something that I'm proposing for real use.