### PR TITLE
Calculate density as weighted sum in popsout

### DIFF
--- a/src/popsout.c
+++ b/src/popsout.c
@@ -26,7 +26,7 @@ popsout(configInfo *par, struct grid *g, molData *m){
   fprintf(fp,"# Column definition: x, y, z, H2 density, kinetic gas temperature, molecular abundance, convergence flag, pops_0...pops_n\n");
   for(j=0;j<par->pIntensity;j++){
     dens=0.;
-    for(l=0;l<par->numDensities;l++) dens+=g[j].dens[l];
+    for(l=0;l<par->numDensities;l++) dens+=g[j].dens[l]*par->nMolWeights[l];
     fprintf(fp,"%e %e %e %e %e %e %d ", g[j].x[0], g[j].x[1], g[j].x[2], dens, g[j].t[0], g[j].mol[0].nmol/dens, g[j].conv);
     for(k=0;k<m[0].nlev;k++) fprintf(fp,"%e ",g[j].mol[0].pops[k]);
     fprintf(fp,"\n");

--- a/src/popsout.c
+++ b/src/popsout.c
@@ -12,7 +12,7 @@
 #include "lime.h"
 
 void
-popsout(configInfo *par, struct grid *g, molData *m){
+popsout(configInfo *par, struct grid *gp, molData *md){
   FILE *fp;
   int j,k,l;
   double dens;
@@ -26,11 +26,11 @@ popsout(configInfo *par, struct grid *g, molData *m){
   fprintf(fp,"# Column definition: x, y, z, H2 density, kinetic gas temperature, molecular abundance, convergence flag, pops_0...pops_n\n");
   for(j=0;j<par->pIntensity;j++){
     dens=0.;
-    for(l=0;l<par->numDensities;l++) dens+=g[j].dens[l]*par->nMolWeights[l];
-    fprintf(fp,"%e %e %e %e %e %e %d ", g[j].x[0], g[j].x[1], g[j].x[2], dens, g[j].t[0], g[j].mol[0].nmol/dens, g[j].conv);
-    for(k=0;k<m[0].nlev;k++) fprintf(fp,"%e ",g[j].mol[0].pops[k]);
+    for(l=0;l<par->numDensities;l++) dens+=gp[j].dens[l]*par->nMolWeights[l];
+    fprintf(fp,"%e %e %e %e %e %e %d ", gp[j].x[0], gp[j].x[1], gp[j].x[2], dens, gp[j].t[0], gp[j].mol[0].nmol/dens, gp[j].conv);
+    for(k=0;k<md[0].nlev;k++) fprintf(fp,"%e ",gp[j].mol[0].pops[k]);
     fprintf(fp,"\n");
-    //fprintf(fp,"%i %lf %lf %lf %lf %lf %lf %lf %lf\n", g[j].id, g[j].x[0], g[j].x[1], g[j].x[2],  g[j].dens[0], g[j].t[0], g[j].vel[0], g[j].vel[1], g[j].vel[2]);
+    //fprintf(fp,"%i %lf %lf %lf %lf %lf %lf %lf %lf\n", gp[j].id, gp[j].x[0], gp[j].x[1], gp[j].x[2],  gp[j].dens[0], gp[j].t[0], gp[j].vel[0], gp[j].vel[1], gp[j].vel[2]);
   }
   fclose(fp);
 }


### PR DESCRIPTION
This method is used to calculate the number density of radiating species
in calcGridMolDensities and it would make sense to do the same here
to return the relative abundance nmol/dens that was provided by the
user.