### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@
 ##
 PREFIX  =  ${PATHTOLIME}
 
+# Paths:
+srcdir		= ${CURDIR}/src
+docdir		= ${CURDIR}/doc
+exampledir	= ${CURDIR}/example
+#*** better to use ${PREFIX} here rather than ${CURDIR}? (the latter is used in artist/lime.)
+
 ifneq (,$(wildcard ${PREFIX}/lib/.))
     LIBS += -L${PREFIX}/lib
 endif
@@ -44,61 +50,55 @@ ifdef OLD_FITSIO
 	CPPFLAGS += -DOLD_FITSIO
 endif
 
+# Names of source files included:
+include Makefile.defs
+
 ##
 ## Do not change anything below unless you know what you are doing! 
 ##
 
-TARGET  = lime.x 
-#CC	= gcc -fopenmp -g -Wunused -Wno-unused-result
+TARGET  = lime.x # Overwritten in usual practice by the value passed in by the 'lime' script.
 CC	= gcc -fopenmp
-SRCS    = src/aux.c src/messages.c src/grid.c src/LTEsolution.c		\
-	  src/main.c src/molinit.c src/photon.c src/popsin.c		\
-	  src/popsout.c src/predefgrid.c src/ratranInput.c		\
-          src/raytrace.c src/smooth.c src/sourcefunc.c src/frees.c	\
-	  src/stateq.c src/statistics.c src/magfieldfit.c		\
-	  src/stokesangles.c src/writefits.c src/tree_random.c		\
-	  src/velospline.c src/getclosest.c src/grid2fits.c		\
-	  src/tcpsocket.c src/defaults.c src/fastexp.c src/gridio.c	\
-	  src/raythrucells.c
-MODELS  = model.c
-OBJS    = src/aux.o src/messages.o src/grid.o src/LTEsolution.o		\
-	  src/main.o src/molinit.o src/photon.o src/popsin.o		\
-	  src/popsout.o src/predefgrid.o src/raytrace.o			\
-	  src/ratranInput.o src/smooth.o src/sourcefunc.o src/frees.o	\
-	  src/stateq.o src/statistics.o src/magfieldfit.o		\
-	  src/stokesangles.o src/writefits.o src/tree_random.o		\
-	  src/velospline.o src/getclosest.o src/grid2fits.o		\
-	  src/tcpsocket.o src/defaults.o src/fastexp.o src/gridio.o	\
-	  src/raythrucells.o
-MODELO 	= src/model.o
+MODELS  = model.c # Overwritten in usual practice by the value passed in by the 'lime' script.
+MODELO 	= ${srcdir}/model.o
 
-#CCFLAGS = -O3 -falign-loops=16 -fno-strict-aliasing -DTEST
 CCFLAGS = -O3 -falign-loops=16 -fno-strict-aliasing
 LDFLAGS = -lgsl -lgslcblas -l${QHULL} -lcfitsio -lncurses -lm 
 
-.SILENT:
+ifeq (${DOTEST},yes)
+  CCFLAGS += -DTEST
+  CC += -g -Wunused -Wno-unused-result
+endif
 
-.PHONY: all clean distclean 
-	all:: ${TARGET} 
+SRCS = ${CORESOURCES} ${STDSOURCES}
+INCS = ${COREINCLUDES}
+OBJS = $(SRCS:.c=.o)
 
-${TARGET}: ${OBJS} ${MODELO} 
-	${CC} -o $@ $^ ${LIBS} ${LDFLAGS}  
+.PHONY: all doc docclean clean distclean
 
-${MODELO}:  
-	${CC} ${CCFLAGS} ${CPPFLAGS} -o ${MODELO} -c ${MODELS}
+all:: ${TARGET} 
 
-${OBJS}: %.o: %.c  
+# Implicit rules:
+%.o : %.c
 	${CC} ${CCFLAGS} ${CPPFLAGS} -o $@ -c $<
 
+${TARGET}: ${OBJS} ${MODELO} 
+	${CC} -o $@ $^ ${LIBS} ${LDFLAGS}
+
+${OBJS} : ${INCS}
+
+${MODELO}: ${INCS}
+	${CC} ${CCFLAGS} ${CPPFLAGS} -o ${MODELO} -c ${MODELS}
+
 doc::
-	mkdir doc/_html || true
-	sphinx-build doc doc/_html
+	mkdir ${docdir}/_html || true
+	sphinx-build doc ${docdir}/_html
 
 docclean::
-	rm -rf doc/_html
+	rm -rf ${docdir}/_html
 
 clean:: 
-	rm -f *~ src/*.o ${TARGET} 
+	rm -f *~ ${srcdir}/*.o ${pydir}/*.pyc ${TARGET} ${PYTARGET}
 
 distclean:: clean docclean
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,0 +1,51 @@
+# Makefile.defs
+# This file is part of LIME, the versatile line modeling engine
+#
+# Copyright (C) 2006-2014 Christian Brinch
+# Copyright (C) 2015-2016 The LIME development team
+#
+# Included by Makefile
+
+CORESOURCES = \
+	src/aux.c\
+	src/fastexp.c\
+	src/frees.c\
+	src/getclosest.c\
+	src/grid2fits.c\
+	src/grid.c\
+	src/gridio.c\
+	src/LTEsolution.c\
+	src/magfieldfit.c\
+	src/messages.c\
+	src/molinit.c\
+	src/photon.c\
+	src/popsin.c\
+	src/popsout.c\
+	src/predefgrid.c\
+	src/ratranInput.c\
+	src/raythrucells.c\
+	src/raytrace.c\
+	src/report.c\
+	src/smooth.c\
+	src/sourcefunc.c\
+	src/stateq.c\
+	src/statistics.c\
+	src/stokesangles.c\
+	src/tcpsocket.c\
+	src/tree_random.c\
+	src/velospline.c\
+	src/writefits.c\
+
+STDSOURCES = \
+	src/defaults.c\
+	src/main.c\
+
+COREINCLUDES = \
+	src/dims.h\
+	src/grid2fits.h\
+	src/gridio.h\
+	src/inpars.h\
+	src/lime.h\
+	src/raythrucells.h\
+	src/tree_random.h\
+

--- a/lime
+++ b/lime
@@ -12,7 +12,7 @@ function version {
 }
 
 function usage {
-    echo "Usage: lime [OPTION] [[FILE]]"
+    echo "Usage: lime [OPTIONS] [[FILE]]"
     echo " "
     echo "Arguments:"
     echo "   FILE   C model file"
@@ -21,6 +21,7 @@ function usage {
     echo "   -V           Display version information"
     echo "   -h           Display this message"
     echo "   -f           Use fast exponential computation"
+    echo "   -t           Compile with debugging and fixed RNG seeds"
     echo "   -n           Turn off ncurses output"
     echo "   -p NTHREADS  Run in parallel with NTHREADS threads (default: 1)"
     echo ""
@@ -32,8 +33,9 @@ function tip {
     echo "Try 'lime -h' for more information."
 }
 
-options=":Vfnp:h"
+options=":Vfntp:h"
 cpp_flags=""
+do_test="no"
 
 while getopts ${options} opt; do
     case $opt in
@@ -61,6 +63,9 @@ while getopts ${options} opt; do
 		exit 1
 	    fi
 	    ;;
+	t)
+	    do_test="yes"
+	    ;;
 	\?)
 	    echo "lime: error: unknown option" >&2
 	    tip
@@ -84,8 +89,8 @@ export WORKDIR=$PWD
 
 # Compile the code
 pushd ${PATHTOLIME} >> /dev/null
-make EXTRACPPFLAGS="${cpp_flags}" MODELS=$WORKDIR/$1 TARGET=$WORKDIR/lime_$$.x
-make clean
+make -s EXTRACPPFLAGS="${cpp_flags}" MODELS=$WORKDIR/$1 TARGET=$WORKDIR/lime_$$.x DOTEST=$do_test
+make -s clean
 
 # Run the code
 popd >> /dev/null

--- a/src/lime.h
+++ b/src/lime.h
@@ -284,7 +284,7 @@ struct cell {
 };
 
 /* Some global variables */
-int silent;
+extern int silent;
 
 /* User-specifiable functions */
 void density(double,double,double,double *);
@@ -400,14 +400,14 @@ void	collpartmesg(char*, int);
 void	collpartmesg2(char*, int);
 void	collpartmesg3(int, int);
 void	goodnight(int, char*);
-void	greetings();
+void	greetings(void);
 void	greetings_parallel(int);
 void	printDone(int);
 void	printMessage(char *);
 void	progressbar(double, int);
 void	progressbar2(configInfo*, int, int, double, double, double);
 void	quotemass(double);
-void	screenInfo();
+void	screenInfo(void);
 void	warning(char*);
 
 #ifdef FASTEXP

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include "lime.h"
 #include "gridio.h"
 
+int silent = 0;
 
 /* Forward declaration of functions only used in this file */
 int initParImg(inputPars *par, image **img);
@@ -168,7 +169,6 @@ run(inputPars inpars, image *inimg, const int nImages){
 #endif
   fillErfTable();
 
-//  par.nImages = nImages;
   parseInput(inpars, inimg, nImages, &par, &img, &md); /* Sets par.numDensities for !(par.doPregrid || par.restart) */
 
   if(!silent && par.nThreads>1){
@@ -263,8 +263,6 @@ int main () {
   inputPars par;
   image	*img = NULL;
   int nImages;
-
-  silent = 0;
 
   mallocInputPars(&par);
   nImages = initParImg(&par, &img);

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -734,10 +734,15 @@ At the present point in the code, for line images, instead of calculating the 'c
       cmbLineI = img[im].trans;
 
     }else{ /* User didn't set trans. Find the nearest line to the image frequency. */
+      minfreq = fabs(img[im].freq - md[0].freq[0]);;
+      cmbMolI = 0;
+      cmbLineI = 0;
       for(molI=0;molI<par->nSpecies;molI++){
         for(lineI=0;lineI<md[molI].nline;lineI++){
+          if((molI==0 && lineI==0)) continue;
+
           absDeltaFreq = fabs(img[im].freq - md[molI].freq[lineI]);
-          if((molI==0 && lineI==0) || absDeltaFreq < minfreq){
+          if(absDeltaFreq < minfreq){
             minfreq = absDeltaFreq;
             cmbMolI = molI;
             cmbLineI = lineI;


### PR DESCRIPTION
Includes some changes to the Makefile which should eventually make it easier to incorporate a python-interface version of Lime; as well as a few small fixes for things which under some circumstances generated compiler warnings or errors on MacOS.

I also included a -t command-line parameter for lime which compiles the code in test format (i.e. with debugger, fixed random seeds). This obviates the need to hack the Makefile each time.