### PR TITLE
Add name of variables in header of populations file

### DIFF
--- a/src/popsout.c
+++ b/src/popsout.c
@@ -23,7 +23,9 @@ popsout(configInfo *par, struct grid *gp, molData *md){
     if(!silent) bail_out("Error writing output populations file!");
     exit(1);
   }
-  fprintf(fp,"# Column definition: x, y, z, H2 density, kinetic gas temperature, molecular abundance, convergence flag, pops_0...pops_n\n");
+  fprintf(fp,"# x y z H2_density kinetic_gas_temperature molecular_abundance convergence_flag");
+  for(k=0;k<md[0].nlev;k++) fprintf(fp," pops_%d",k);
+  fprintf(fp,"\n");
   for(j=0;j<par->pIntensity;j++){
     dens=0.;
     for(l=0;l<par->numDensities;l++) dens+=gp[j].dens[l]*par->nMolWeights[l];


### PR DESCRIPTION
Although the ascii output is going to be deprecated it is still used to read the output populations. This changes the header to use whitespace delimiter for column names as in the rest of the file. The population file can then be read as CSV file by data analysis tools such as python pandas without having to specify
column names manually.