### PR TITLE
Reinstates subtraction of CMB at the end of each ray trace.

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -173,11 +173,6 @@ The parameters visible to the user have now been strictly confined to members of
   while(i<MAX_N_HIGH && par->gridDensMaxValues[i]>=0) i++;
   par->numGridDensMaxima = i;
 
-  /* Check that the user has supplied the velocity function (needed in raytracing unless par->doPregrid). Note that the other previously mandatory functions (density, abundance, doppler and temperature) may not be necessary if the user reads in the appropriate values from a file. This is tested at the appropriate place in readOrBuildGrid().
-  */
-  if(!par->doPregrid || par->traceRayAlgorithm==1)
-    velocity(0.0,0.0,0.0, dummyVel);
-
   /* Calculate par->numDensities.
   */
   if(!(par->doPregrid || par->restart)){ /* These switches cause par->numDensities to be set in routines they call. */
@@ -493,6 +488,11 @@ LIME provides two different schemes of {R_1, R_2, R_3}: {PA, phi, theta} and {PA
     else
       par->nContImages++;
   }
+
+  /* Check that the user has supplied the velocity function (needed in raytracing unless par->doPregrid). Note that the other previously mandatory functions (density, abundance, doppler and temperature) may not be necessary if the user reads in the appropriate values from a file. This is tested at the appropriate place in readOrBuildGrid().
+  */
+  if(par->nLineImages>0 && (!par->doPregrid || par->traceRayAlgorithm==1))
+    velocity(0.0,0.0,0.0, dummyVel);
 
   /* Allocate moldata array.
   */

--- a/src/grid.c
+++ b/src/grid.c
@@ -5,6 +5,8 @@
  *  Copyright (C) 2006-2014 Christian Brinch
  *  Copyright (C) 2015-2016 The LIME development team
  *
+TODO:
+	- In readOrBuildGrid(), test for the presence of the 5 mandatory functions (actually 4, since velocity() is already tested in aux.c:parseInput() ) before doing smoothing.
  */
 
 #include "lime.h"

--- a/src/lime.h
+++ b/src/lime.h
@@ -69,11 +69,12 @@
 #define PI                      3.14159265358979323846	/* pi	*/
 #define SPI                     1.77245385091		/* sqrt(pi)	*/
 #define maxp                    0.15
-#define NITERATIONS 		16
+#define NITERATIONS             16
 #define MAX_RAYS_PER_POINT      10000
-#define RAYS_PER_POINT		200
+#define RAYS_PER_POINT          200
 #define minpop                  1.e-6
 #define eps                     1.0e-30
+#define IMG_MIN_ALLOWED         1.0e-30
 #define TOL                     1e-6
 #define MAXITER                 50
 #define goal                    50
@@ -82,22 +83,22 @@
 #define MAX_NSPECIES            100
 #define MAX_NIMAGES             100
 #define N_RAN_PER_SEGMENT       3
-#define FAST_EXP_MAX_TAYLOR	3
-#define FAST_EXP_NUM_BITS	8
-#define NUM_GRID_STAGES		4
-#define MAX_N_COLL_PART		7
+#define FAST_EXP_MAX_TAYLOR     3
+#define FAST_EXP_NUM_BITS       8
+#define NUM_GRID_STAGES         4
+#define MAX_N_COLL_PART         7
 #define N_SMOOTH_ITERS          20
 #define TYPICAL_ISM_DENS        1000.0
 #define STR_LEN_0               80
-#define DENSITY_POWER		0.2
+#define DENSITY_POWER           0.2
 #define MAX_N_HIGH              10
-#define TREE_POWER		2.0
-#define ERF_TABLE_LIMIT		6.0             /* For x>6 erf(x)-1<double precision machine epsilon, so no need to store the values for larger x. */
-#define ERF_TABLE_SIZE		6145
-#define BIN_WIDTH		(ERF_TABLE_LIMIT/(ERF_TABLE_SIZE-1.))
-#define IBIN_WIDTH 		(1./BIN_WIDTH)
-#define N_VEL_SEG_PER_HALF	1
-#define NUM_VEL_COEFFS		(1+2*N_VEL_SEG_PER_HALF) /* This is the number of velocity samples per edge (not including the grid vertices at each end of the edge). Currently this is elsewhere hard-wired at 3, the macro just being used in the file I/O modules. Note that we want an odd number of velocity samples per edge if we want to have the ability to do 2nd-order interpolation of velocity within Delaunay tetrahedra. */
+#define TREE_POWER              2.0
+#define ERF_TABLE_LIMIT         6.0             /* For x>6 erf(x)-1<double precision machine epsilon, so no need to store the values for larger x. */
+#define ERF_TABLE_SIZE          6145
+#define BIN_WIDTH               (ERF_TABLE_LIMIT/(ERF_TABLE_SIZE-1.))
+#define IBIN_WIDTH              (1./BIN_WIDTH)
+#define N_VEL_SEG_PER_HALF      1
+#define NUM_VEL_COEFFS          (1+2*N_VEL_SEG_PER_HALF) /* This is the number of velocity samples per edge (not including the grid vertices at each end of the edge). Currently this is elsewhere hard-wired at 3, the macro just being used in the file I/O modules. Note that we want an odd number of velocity samples per edge if we want to have the ability to do 2nd-order interpolation of velocity within Delaunay tetrahedra. */
 
 /* Collision partner ID numbers from LAMDA */
 #define CP_H2			1

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -884,8 +884,12 @@ How to calculate this distance? Well if we have N points randomly but evenly dis
     rSqu = gp[gi].x[0]*gp[gi].x[0] + gp[gi].x[1]*gp[gi].x[1];
     if(rSqu > (4.0/9.0)*par->radiusSqu) numPointsInAnnulus += 1;
   }
-  circleSpacing = (1.0/6.0)*par->radius*sqrt(5.0*PI/(double)numPointsInAnnulus);
-  numCircleRays = (int)(2.0*PI*par->radius/circleSpacing);
+  if(numPointsInAnnulus>0){
+    circleSpacing = (1.0/6.0)*par->radius*sqrt(5.0*PI/(double)numPointsInAnnulus);
+    numCircleRays = (int)(2.0*PI*par->radius/circleSpacing);
+  }else{
+    numCircleRays = 0;
+  }
 
   /* The following is the first of the 3 main loops in raytrace. Here we loop over the (internal or non-sink) grid points. We're doing 2 things: loading the rotated, projected coordinates into the rays list, and counting the rays per image pixel.
   */

--- a/src/writefits.c
+++ b/src/writefits.c
@@ -131,7 +131,7 @@ write3Dfits(int im, configInfo *par, imageInfo *img){
           if(!silent) bail_out("Image unit number invalid");
           exit(0);
         }
-        if (fabs(row[px])<(float) eps) row[px]=(float)eps;
+        if (fabs(row[px])<IMG_MIN_ALLOWED) row[px]=IMG_MIN_ALLOWED;
       }
       fpixels[0]=1;
       fpixels[1]=py+1;
@@ -242,7 +242,7 @@ write2Dfits(int im, configInfo *par, imageInfo *img){
   }
 
   if(img[im].unit<5)
-    minVal = eps;
+    minVal = IMG_MIN_ALLOWED;
   else
     minVal = 0.0;
 


### PR DESCRIPTION
In traceray() and traceray_smooth() the subtraction of local_cmb from the ray intensities has been reinstated (it was removed from 1.6 since Tuomas and I did not understand its purpose).

This should fix #206.