### PR TITLE
par->nSpecies now left at 0 if no moldata files.

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -118,9 +118,8 @@ The parameters visible to the user have now been strictly confined to members of
 
   /* Copy over the moldatfiles.
   */
-  if(par->nSpecies == 0){
-    par->nSpecies = 1;/* ******************* should not confuse continuum and line in this way. */
-    par->moldatfile = NULL;
+  if(par->nSpecies <= 0){
+    par->moldatfile = NULL; /* This will be tested for all line images, so we can never get par->nLineImages>0 if no moldata files have been supplied. */
 
   } else {
     par->moldatfile=malloc(sizeof(char *)*par->nSpecies);
@@ -481,19 +480,21 @@ LIME provides two different schemes of {R_1, R_2, R_3}: {PA, phi, theta} and {PA
 
   /* Allocate moldata array.
   */
-  (*md)=malloc(sizeof(molData)*par->nSpecies);
-  for( i=0; i<par->nSpecies; i++ ){
-    (*md)[i].part = NULL;
-    (*md)[i].lal = NULL;
-    (*md)[i].lau = NULL;
-    (*md)[i].aeinst = NULL;
-    (*md)[i].freq = NULL;
-    (*md)[i].beinstu = NULL;
-    (*md)[i].beinstl = NULL;
-    (*md)[i].eterm = NULL;
-    (*md)[i].gstat = NULL;
-    (*md)[i].cmb = NULL;
-  }
+  if(par->nSpecies>0){
+    (*md)=malloc(sizeof(molData)*par->nSpecies);
+    for( i=0; i<par->nSpecies; i++ ){
+      (*md)[i].part = NULL;
+      (*md)[i].lal = NULL;
+      (*md)[i].lau = NULL;
+      (*md)[i].aeinst = NULL;
+      (*md)[i].freq = NULL;
+      (*md)[i].beinstu = NULL;
+      (*md)[i].beinstl = NULL;
+      (*md)[i].eterm = NULL;
+      (*md)[i].gstat = NULL;
+      (*md)[i].cmb = NULL;
+    }
+  } /* otherwise leave it at NULL - we will not be using it. */
 }
 
 void checkUserDensWeights(configInfo *par){

--- a/src/grid.c
+++ b/src/grid.c
@@ -955,7 +955,7 @@ void writeGridIfRequired(configInfo *par, struct grid *gp, molData *md, const in
       gridInfo.mols = NULL;
     else{
       gridInfo.mols = malloc(sizeof(*(gridInfo.mols))*gridInfo.nSpecies);
-      for(i_us=0;i_us<gridInfo.nSpecies;i_us++){
+      for(i_us=0;i_us<gridInfo.nSpecies;i_us++){ /* md should only ==NULL if gridInfo.nSpecies==0. */
         gridInfo.mols[i_us].molName = md[i_us].molName; /* NOTE*** this just copies the pointer. Should be safe enough if we just want to read this value. */
         gridInfo.mols[i_us].nLevels = md[i_us].nlev;
         gridInfo.mols[i_us].nLines  = md[i_us].nline;

--- a/src/main.c
+++ b/src/main.c
@@ -15,7 +15,7 @@ int silent = 0;
 
 /* Forward declaration of functions only used in this file */
 int initParImg(inputPars *par, image **img);
-int main ();
+int main();
 
 
 
@@ -257,7 +257,7 @@ run(inputPars inpars, image *inimg, const int nImages){
   }
 }
 
-int main () {
+int main() {
   /* Main program for stand-alone LIME */
 
   inputPars par;


### PR DESCRIPTION
At line 122 of aux.c there was a line resetting par->nSpecies artificially to 1 if the user had supplied no moldata files (thus giving a real value of zero for par->nSpecies). This ugly expedient is no longer necessary since the molData struct is no longer used to store continuum values.

The molData pointer is now also left at NULL if par->nSpecies==0.