### PR TITLE
Units-string-input

### DIFF
--- a/example/model.c
+++ b/example/model.c
@@ -116,14 +116,15 @@ input(inputPars *par, image *img){
    *        2:SI
    *        3:Lsun/pixel
    *        4:tau
-   * The unit name is then added automatically. If img[].filename does not have an extension then '.fits' will be
-   * appended automatically. Otherwise the existing extension is maintained.
+   * If multiple units are specified for a single set of image parameters (e.g. "0 1 2") then the unit name is added
+   * automatically at the end of the given filename, but before the filename extension if it exists. Otherwise if a
+   * single unit is specified then the filename is unchanged.
 
    * A single image unit can also be specified for each image using img[].unit as in previous LIME versions. Note that
    * only img[].units or img[].unit should be set for each image.
   */
 //  img[i].unit                   = 0;
-  img[i].units                  = "0 1";
+  img[i].units                  = "0 1 2";
   img[i].filename               = "image0";        // Output filename
 }
 

--- a/example/model.c
+++ b/example/model.c
@@ -108,6 +108,7 @@ input(inputPars *par, image *img){
   img[i].azimuth                = 0.0;
   img[i].incl                   = 0.0;
   img[i].posang                 = 0.0;
+
   /* For each set of image parameters above, numerous images with different units can be outputted. This is done by
    * setting img[].units to a delimited (space, comma, colon, underscore) string of the required outputs, where:
    *        0:Kelvin
@@ -115,10 +116,15 @@ input(inputPars *par, image *img){
    *        2:SI
    *        3:Lsun/pixel
    *        4:tau
-   * The unit name and file extension is then added automatically.
+   * The unit name is then added automatically. If img[].filename does not have an extension then '.fits' will be
+   * appended automatically. Otherwise the existing extension is maintained.
+
+   * A single image unit can also be specified for each image using img[].unit as in previous LIME versions. Note that
+   * only img[].units or img[].unit should be set for each image.
   */
+//  img[i].unit                   = 0;
   img[i].units                  = "0 1";
-  img[i].filename               = "image0";  // Output filename
+  img[i].filename               = "image0";        // Output filename
 }
 
 /******************************************************************************/

--- a/example/model.c
+++ b/example/model.c
@@ -105,11 +105,20 @@ input(inputPars *par, image *img){
   img[i].imgres                 = 0.1;            // Resolution in arc seconds
   img[i].distance               = 140*PC;         // source distance in m
   img[i].source_vel             = 0;              // source velocity in m/s
-  img[i].unit                   = 0;              // 0:Kelvin 1:Jansky/pixel 2:SI 3:Lsun/pixel 4:tau
-  img[i].filename               = "image0.fits";  // Output filename
   img[i].azimuth                = 0.0;
   img[i].incl                   = 0.0;
   img[i].posang                 = 0.0;
+  /* For each set of image parameters above, numerous images with different units can be outputted. This is done by
+   * setting img[].units to a delimited (space, comma, colon, underscore) string of the required outputs, where:
+   *        0:Kelvin
+   *        1:Jansky/pixel
+   *        2:SI
+   *        3:Lsun/pixel
+   *        4:tau
+   * The unit name and file extension is then added automatically.
+  */
+  img[i].units                  = "0 1";
+  img[i].filename               = "image0";  // Output filename
 }
 
 /******************************************************************************/

--- a/src/aux.c
+++ b/src/aux.c
@@ -246,6 +246,9 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
     if((*img)[i].units == NULL){
       (*img)[i].numunits = 1;
       (*img)[i].imgunits = realloc((*img)[i].imgunits, sizeof(int));
+      if((*img)[i].imgunits == NULL){
+        if(!silent) bail_out("Error allocating memory for single unit");
+      }
       (*img)[i].imgunits[0] = inimg[i].unit;
     }
     else{
@@ -257,9 +260,9 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
       while(pch){
         (*img)[i].imgunits = realloc((*img)[i].imgunits, sizeof(int) * j++);
         if((*img)[i].imgunits == NULL){
-          if(!silent) bail_out("Error allocating memory for units");
+          if(!silent) bail_out("Error allocating memory for multiple units");
         }
-        (*img)[i].imgunits[j-1] = strtol(pch, &pch_end, 0);
+        (*img)[i].imgunits[j-1] = (int)strtol(pch, &pch_end, 0);
         if(*pch_end){
           sprintf(message, "Units string contains '%s' which could not be converted to an integer", pch_end);
           if(!silent) bail_out(message);

--- a/src/aux.c
+++ b/src/aux.c
@@ -241,7 +241,8 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
   /* Allocate pixel space and parse image information.
   */
   for(i=0;i<nImages;i++){
-
+      
+    (*img)[i].imgunits = NULL;
     /* If user has not supplied a units string then use unit value (default 0) to maintain backwards compatibility */
     if((*img)[i].units == NULL){
       (*img)[i].numunits = 1;

--- a/src/aux.c
+++ b/src/aux.c
@@ -63,6 +63,7 @@ The parameters visible to the user have now been strictly confined to members of
   double cos_pa,sin_pa,cosPhi,sinPhi,cos_incl,sin_incl,cosTheta,sinTheta,cos_az,sin_az;
   double tempRotMat[3][3],auxRotMat[3][3];
   int row,col;
+  char *pch_sep = " ,:_", *pch, *units_str;
 
   /* Check that the mandatory parameters now have 'sensible' settings (i.e., that they have been set at all). Raise an exception if not. */
   if (inpar.radius<=0){
@@ -184,7 +185,8 @@ The parameters visible to the user have now been strictly confined to members of
     /* Find out how many density functions we have (which sets par->numDensities).
     */
     for(i=0;i<MAX_N_COLL_PART;i++) dens[i] = -1.0;
-    density(0.0,0.0,0.0,dens); /* Note that the example density function in LIME-1.5 generated a singularity at r==0! Such uglinesses should not be encouraged. I've fixed it now, thus I can use 0s here in (relative) safety. */
+    density(0.0,0.0,0.0,dens); /* Note that the example density function in LIME-1.5 generated a singularity at r==0!
+ * Such uglinesses should not be encouraged. I've fixed it now, thus I can use 0s here in (relative) safety. */
     i = 0;
     while(i<MAX_N_COLL_PART && dens[i]>=0) i++;
     par->numDensities = i;
@@ -195,7 +197,8 @@ The parameters visible to the user have now been strictly confined to members of
     }
   }
 
-  /* See if we can deduce a global maximum for the grid point number density function. Set the starting value from the unnormalized number density at the origin of coordinates:
+  /* See if we can deduce a global maximum for the grid point number density function. Set the starting value from the
+   * unnormalized number density at the origin of coordinates:
   */
   par->gridDensGlobalMax = 1.0;
   for(i=0;i<DIM;i++) r[i] = par->minScale;//****0.0;
@@ -244,7 +247,9 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
     (*img)[i].velres     = inimg[i].velres;
     (*img)[i].imgres     = inimg[i].imgres;
     (*img)[i].pxls       = inimg[i].pxls;
-    (*img)[i].unit       = inimg[i].unit;
+    copyInparStr(inimg[i].units, &((*img)[i].units));
+    (*img)[i].imgunits       = inimg[i].imgunits;
+    (*img)[i].numunits       = inimg[i].numunits;
     (*img)[i].freq       = inimg[i].freq;
     (*img)[i].bandwidth  = inimg[i].bandwidth;
     copyInparStr(inimg[i].filename, &((*img)[i].filename));
@@ -260,6 +265,22 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
   /* Allocate pixel space and parse image information.
   */
   for(i=0;i<nImages;i++){
+  
+  	/* Parse image units, populate imgunits array with appropriate image identifiers and track number of units
+     * requested for each image */
+    copyInparStr((*img)[i].units, &(units_str));
+    pch = strtok(units_str, pch_sep);
+    j = 0;
+    while(pch){
+      (*img)[i].imgunits = realloc((*img)[i].imgunits, sizeof(int) * j++);
+      if((*img)[i].imgunits == NULL){
+        if(!silent) bail_out("Error allocating memory for units");
+      }
+      (*img)[i].imgunits[j-1] = strtol(pch, NULL, 0);
+      pch = strtok(NULL, pch_sep);
+    }
+    (*img)[i].numunits = j;
+    
     if((*img)[i].nchan == 0 && (*img)[i].velres<0 ){ /* => user has set neither nchan nor velres. One of the two is required for a line image. */
       /* Assume continuum image */
 

--- a/src/defaults.c
+++ b/src/defaults.c
@@ -56,12 +56,16 @@ void __attribute__((weak))
 double __attribute__((weak))
     gridDensity(configInfo *par, double *r){
       /*
-The grid points within the model are chosen randomly via the rejection method with a probability distribution which the present function is intended to provide.
+The grid points within the model are chosen randomly via the rejection method with a probability distribution which the
+       present function is intended to provide.
 
 Notes:
-  - The present function is interpreted by LIME as giving *relative* probabilities, the ultimate normalization being set by the desired number of grid points conveyed to the task via par->pIntensity.
-  - If par->samplingAlgorithm is chosen to be zero (the current default value), further manipulations to the probability distribution are performed according to the set value of par->sampling.
-  - The user may supply their own version of the present function within model.c; the default here implements the grid-point selection function used in LIME<=1.5.
+  - The present function is interpreted by LIME as giving *relative* probabilities, the ultimate normalization being set
+       by the desired number of grid points conveyed to the task via par->pIntensity.
+  - If par->samplingAlgorithm is chosen to be zero (the current default value), further manipulations to the probability
+       distribution are performed according to the set value of par->sampling.
+  - The user may supply their own version of the present function within model.c; the default here implements the
+       grid-point selection function used in LIME<=1.5.
       */
       double val[99],totalDensity=0.0,rSquared=0.0,fracDensity=0.0;
       int i;

--- a/src/defaults.c
+++ b/src/defaults.c
@@ -56,16 +56,12 @@ void __attribute__((weak))
 double __attribute__((weak))
     gridDensity(configInfo *par, double *r){
       /*
-The grid points within the model are chosen randomly via the rejection method with a probability distribution which the
-       present function is intended to provide.
+The grid points within the model are chosen randomly via the rejection method with a probability distribution which the present function is intended to provide.
 
 Notes:
-  - The present function is interpreted by LIME as giving *relative* probabilities, the ultimate normalization being set
-       by the desired number of grid points conveyed to the task via par->pIntensity.
-  - If par->samplingAlgorithm is chosen to be zero (the current default value), further manipulations to the probability
-       distribution are performed according to the set value of par->sampling.
-  - The user may supply their own version of the present function within model.c; the default here implements the
-       grid-point selection function used in LIME<=1.5.
+  - The present function is interpreted by LIME as giving *relative* probabilities, the ultimate normalization being set by the desired number of grid points conveyed to the task via par->pIntensity.
+  - If par->samplingAlgorithm is chosen to be zero (the current default value), further manipulations to the probability distribution are performed according to the set value of par->sampling.
+  - The user may supply their own version of the present function within model.c; the default here implements the grid-point selection function used in LIME<=1.5.
       */
       double val[99],totalDensity=0.0,rSquared=0.0,fracDensity=0.0;
       int i;

--- a/src/frees.c
+++ b/src/frees.c
@@ -80,6 +80,7 @@ freeImgInfo(const int nImages, imageInfo *img){
     }
     free(img[i].pixel);
     free(img[i].filename);
+    free(img[i].imgunits);
   }
   free(img);
 }

--- a/src/inpars.h
+++ b/src/inpars.h
@@ -34,9 +34,8 @@ typedef struct {
   double velres;
   double imgres;
   int pxls;
+  int unit;
   char *units;
-  int *imgunits;
-  int numunits;
   double freq,bandwidth;
   char *filename;
   double source_vel;

--- a/src/inpars.h
+++ b/src/inpars.h
@@ -34,7 +34,9 @@ typedef struct {
   double velres;
   double imgres;
   int pxls;
-  int unit;
+  char *units;
+  int *imgunits;
+  int numunits;
   double freq,bandwidth;
   char *filename;
   double source_vel;

--- a/src/lime.h
+++ b/src/lime.h
@@ -332,7 +332,7 @@ void    fillErfTable();
 void	fit_d1fi(double, double, double*);
 void	fit_fi(double, double, double*);
 void	fit_rr(double, double, double*);
-void    fitsFilename(char *, configInfo *, imageInfo *, const int, const int);
+void    insertUnitsStrInFilename(char *, configInfo *, imageInfo *, const int, const int);
 void	freeConfigInfo(configInfo par);
 void	freeGrid(const unsigned int, const unsigned short, struct grid*);
 void	freeGridPointData(const int, gridPointData*);

--- a/src/lime.h
+++ b/src/lime.h
@@ -240,7 +240,9 @@ typedef struct {
   double velres;
   double imgres;
   int pxls;
-  int unit;
+  char *units;
+  int *imgunits;
+  int numunits;
   double freq,bandwidth;
   char *filename;
   double source_vel;
@@ -329,6 +331,7 @@ void    fillErfTable();
 void	fit_d1fi(double, double, double*);
 void	fit_fi(double, double, double*);
 void	fit_rr(double, double, double*);
+void    fitsFilename(char *, configInfo *, imageInfo *, const int, const int);
 void	freeConfigInfo(configInfo par);
 void	freeGrid(const unsigned int, const unsigned short, struct grid*);
 void	freeGridPointData(const int, gridPointData*);
@@ -384,9 +387,9 @@ void	stateq(int, struct grid*, molData*, const int, configInfo*, struct blendInf
 void	statistics(int, molData*, struct grid*, int*, double*, double*, int*);
 void	stokesangles(double*, double (*rotMat)[3], double*);
 double	taylor(const int, const float);
-void	write2Dfits(int, configInfo*, imageInfo*);
-void	write3Dfits(int, configInfo*, imageInfo*);
-void	writeFits(const int, configInfo*, imageInfo*);
+void	write2Dfits(int, int, configInfo*, imageInfo*);
+void	write3Dfits(int, int, configInfo*, imageInfo*);
+void	writeFits(const int, const int, configInfo*, imageInfo*);
 void	writeGridIfRequired(configInfo*, struct grid*, molData*, const int);
 void	write_VTK_unstructured_Points(configInfo*, struct grid*);
 

--- a/src/lime.h
+++ b/src/lime.h
@@ -323,6 +323,7 @@ void	calcSourceFn(double, const configInfo*, double*, double*);
 void	calcTableEntries(const int, const int);
 void	checkGridDensities(configInfo*, struct grid*);
 void	checkUserDensWeights(configInfo*);
+void    copyInparStr(const char*, char**);
 void	delaunay(const int, struct grid*, const unsigned long, const _Bool, const _Bool, struct cell**, unsigned long*);
 void	distCalc(configInfo*, struct grid*);
 double	dotProduct3D(const double*, const double*);

--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,7 @@ initParImg(inputPars *par, image **img)
   (*img)=malloc(sizeof(**img)*MAX_NIMAGES);
   for(i=0;i<MAX_NIMAGES;i++){
     (*img)[i].filename=NULL;
+    (*img)[i].units=NULL;
   }
 
   /* First call to the user function which sets par, img values. Note that, as far as img is concerned, here we just want to find out how many images the user wants, so we can malloc the array properly. We call input() a second time then to get the actual per-image parameter values.
@@ -198,11 +199,16 @@ run(inputPars inpars, image *inimg, const int nImages){
   if(par.nContImages>0){
     for(i=0;i<par.nImages;i++){
       if(!img[i].doline){
-        copyInparStr(img[i].filename, &(img_filename_root));
         raytrace(i, &par, gp, md, img, lamtab, kaptab, nEntries);
-        for(j=0;j<img[i].numunits;j++) {
-          insertUnitStrInFilename(img_filename_root, &par, img, i, j);
-          writeFits(i,j,&par,img);
+        if(img[i].numunits == 1){
+          writeFits(i,0,&par,img);
+        }
+        else{
+          copyInparStr(img[i].filename, &(img_filename_root));
+          for(j=0;j<img[i].numunits;j++) {
+            insertUnitStrInFilename(img_filename_root, &par, img, i, j);
+            writeFits(i,j,&par,img);
+          }
         }
       }
     }
@@ -245,11 +251,16 @@ run(inputPars inpars, image *inimg, const int nImages){
   if(par.nLineImages>0){
     for(i=0;i<par.nImages;i++){
       if(img[i].doline){
-        copyInparStr(img[i].filename, &(img_filename_root));
         raytrace(i, &par, gp, md, img, lamtab, kaptab, nEntries);
-        for(j=0;j<img[i].numunits;j++) {
-          insertUnitStrInFilename(img_filename_root, &par, img, i, j);
-          writeFits(i,j,&par,img);
+        if(img[i].numunits == 1){
+          writeFits(i,0,&par,img);
+        }
+        else{
+          copyInparStr(img[i].filename, &(img_filename_root));
+          for(j=0;j<img[i].numunits;j++) {
+            insertUnitStrInFilename(img_filename_root, &par, img, i, j);
+            writeFits(i,j,&par,img);
+          }
         }
       }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -102,7 +102,6 @@ initParImg(inputPars *par, image **img)
   (*img)=malloc(sizeof(**img)*MAX_NIMAGES);
   for(i=0;i<MAX_NIMAGES;i++){
     (*img)[i].filename=NULL;
-    (*img)[i].imgunits= NULL;
   }
 
   /* First call to the user function which sets par, img values. Note that, as far as img is concerned, here we just want to find out how many images the user wants, so we can malloc the array properly. We call input() a second time then to get the actual per-image parameter values.
@@ -132,6 +131,7 @@ initParImg(inputPars *par, image **img)
     (*img)[i].incl    = defaultAngle;
     (*img)[i].azimuth = defaultAngle;
     (*img)[i].posang  = defaultAngle;
+    (*img)[i].unit = 0;
   }
 
   /* Second-pass reading of the user-set parameters (this time just to read the par->moldatfile and img stuff). */
@@ -159,7 +159,7 @@ run(inputPars inpars, image *inimg, const int nImages){
   char message[80];
   int nEntries=0;
   double *lamtab=NULL, *kaptab=NULL;
-  char *fits_filename;
+  char *img_filename_root;
 
   /*Set locale to avoid trouble when reading files*/
   setlocale(LC_ALL, "C");
@@ -198,11 +198,11 @@ run(inputPars inpars, image *inimg, const int nImages){
   if(par.nContImages>0){
     for(i=0;i<par.nImages;i++){
       if(!img[i].doline){
-        copyInparStr(img[i].filename, &(fits_filename));
+        copyInparStr(img[i].filename, &(img_filename_root));
         raytrace(i, &par, gp, md, img, lamtab, kaptab, nEntries);
         for(j=0;j<img[i].numunits;j++) {
-	        fitsFilename(fits_filename, &par, img, i, j);
-        	writeFits(i,j,&par,img);
+          insertUnitStrInFilename(img_filename_root, &par, img, i, j);
+          writeFits(i,j,&par,img);
         }
       }
     }
@@ -245,11 +245,11 @@ run(inputPars inpars, image *inimg, const int nImages){
   if(par.nLineImages>0){
     for(i=0;i<par.nImages;i++){
       if(img[i].doline){
-        copyInparStr(img[i].filename, &(fits_filename));
+        copyInparStr(img[i].filename, &(img_filename_root));
         raytrace(i, &par, gp, md, img, lamtab, kaptab, nEntries);
         for(j=0;j<img[i].numunits;j++) {
-	        fitsFilename(fits_filename, &par, img, i, j);
-        	writeFits(i,j,&par,img);
+          insertUnitStrInFilename(img_filename_root, &par, img, i, j);
+          writeFits(i,j,&par,img);
         }
       }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -100,8 +100,10 @@ initParImg(inputPars *par, image **img)
 
   /* Allocate initial space for output fits images */
   (*img)=malloc(sizeof(**img)*MAX_NIMAGES);
-  for(i=0;i<MAX_NIMAGES;i++)
+  for(i=0;i<MAX_NIMAGES;i++){
     (*img)[i].filename=NULL;
+    (*img)[i].imgunits= NULL;
+  }
 
   /* First call to the user function which sets par, img values. Note that, as far as img is concerned, here we just want to find out how many images the user wants, so we can malloc the array properly. We call input() a second time then to get the actual per-image parameter values.
   */
@@ -147,7 +149,7 @@ run(inputPars inpars, image *inimg, const int nImages){
      programs. In this case, inpars and img must be specified by the
      external program.
   */
-  int i,gi,si;
+  int i,j,gi,si;
   int initime=time(0);
   int popsdone=0;
   molData *md=NULL;
@@ -156,7 +158,8 @@ run(inputPars inpars, image *inimg, const int nImages){
   struct grid *gp=NULL;
   char message[80];
   int nEntries=0;
-  double *lamtab=NULL, *kaptab=NULL; 
+  double *lamtab=NULL, *kaptab=NULL;
+  char *fits_filename;
 
   /*Set locale to avoid trouble when reading files*/
   setlocale(LC_ALL, "C");
@@ -195,8 +198,12 @@ run(inputPars inpars, image *inimg, const int nImages){
   if(par.nContImages>0){
     for(i=0;i<par.nImages;i++){
       if(!img[i].doline){
+        copyInparStr(img[i].filename, &(fits_filename));
         raytrace(i, &par, gp, md, img, lamtab, kaptab, nEntries);
-        writeFits(i,&par,img);
+        for(j=0;j<img[i].numunits;j++) {
+	        fitsFilename(fits_filename, &par, img, i, j);
+        	writeFits(i,j,&par,img);
+        }
       }
     }
   }
@@ -238,8 +245,12 @@ run(inputPars inpars, image *inimg, const int nImages){
   if(par.nLineImages>0){
     for(i=0;i<par.nImages;i++){
       if(img[i].doline){
+        copyInparStr(img[i].filename, &(fits_filename));
         raytrace(i, &par, gp, md, img, lamtab, kaptab, nEntries);
-        writeFits(i,&par,img);
+        for(j=0;j<img[i].numunits;j++) {
+	        fitsFilename(fits_filename, &par, img, i, j);
+        	writeFits(i,j,&par,img);
+        }
       }
     }
   }

--- a/src/writefits.c
+++ b/src/writefits.c
@@ -9,19 +9,39 @@
 
 #include "lime.h"
 
-void writeFits(const int i, configInfo *par, imageInfo *img){
-  if(img[i].unit<5)
-    write3Dfits(i,par,img);
-  else if(img[i].unit==5)
-    write2Dfits(i,par,img);
+void writeFits(const int i, const int unit, configInfo *par, imageInfo *img){
+  if(img[i].imgunits[unit]<5)
+    write3Dfits(i,unit,par,img);
+  else if(img[i].imgunits[unit]==5)
+    write2Dfits(i,unit,par,img);
   else{
     if(!silent) bail_out("Image unit number invalid");
     exit(0);
   }
 }
 
+void fitsFilename(char *fits_filename, configInfo *par, imageInfo *img, const int im, const int unit){
+  char *temp_filename;
+  static char* unit_names[] = {"Kelvin", "Jansky-per-px", "SI", "LSun-per-px", "Tau", "#Rays"};
+
+  /* Check unit number has a corresponding unit name */
+  if(img[im].numunits < 0 || img[im].numunits > sizeof(unit_names)/sizeof(*unit_names) - 1){
+    if(!silent) bail_out("Image unit number does not have a corresponding unit name");
+    exit(0);
+  }
+
+  /* Append unit name to temporary filename */
+  copyInparStr(fits_filename, &(temp_filename));
+  strcat(temp_filename, "_");
+  strcat(temp_filename, unit_names[img[im].imgunits[unit]]);
+  strcat(temp_filename, ".fits");
+
+  /* Update image filename from temporary filename */
+  copyInparStr(temp_filename, &(img[im].filename));
+}
+
 void 
-write3Dfits(int im, configInfo *par, imageInfo *img){
+write3Dfits(int im, int unit, configInfo *par, imageInfo *img){
   double bscale,bzero,epoch,lonpole,equinox,restfreq;
   double cdelt1,crpix1,crval1,cdelt2,crpix2,crval2;
   double cdelt3,crpix3,crval3,ru3,scale;
@@ -96,23 +116,27 @@ write3Dfits(int im, configInfo *par, imageInfo *img){
   fits_write_key(fptr, TSTRING, "CUNIT3  ", &"M/S     ",    "", &status);
   fits_write_key(fptr, TDOUBLE, "BSCALE  ", &bscale,        "", &status);
   fits_write_key(fptr, TDOUBLE, "BZERO   ", &bzero,         "", &status);
-  if(img[im].unit==0) fits_write_key(fptr, TSTRING, "BUNIT", &"K       ", "", &status);
-  if(img[im].unit==1) fits_write_key(fptr, TSTRING, "BUNIT", &"JY/PIXEL", "", &status);
-  if(img[im].unit==2) fits_write_key(fptr, TSTRING, "BUNIT", &"WM2HZSR ", "", &status);
-  if(img[im].unit==3) fits_write_key(fptr, TSTRING, "BUNIT", &"Lsun/PX ", "", &status);
-  if(img[im].unit==4) fits_write_key(fptr, TSTRING, "BUNIT", &"        ", "", &status);
+  if(img[im].imgunits[unit]==0) fits_write_key(fptr, TSTRING, "BUNIT", &"K       ", "", &status);
+  if(img[im].imgunits[unit]==1) fits_write_key(fptr, TSTRING, "BUNIT", &"JY/PIXEL", "", &status);
+  if(img[im].imgunits[unit]==2) fits_write_key(fptr, TSTRING, "BUNIT", &"WM2HZSR ", "", &status);
+  if(img[im].imgunits[unit]==3) fits_write_key(fptr, TSTRING, "BUNIT", &"Lsun/PX ", "", &status);
+  if(img[im].imgunits[unit]==4) fits_write_key(fptr, TSTRING, "BUNIT", &"        ", "", &status);
+  if(img[im].imgunits[unit]==5) fits_write_key(fptr, TSTRING, "BUNIT", &"N_RAYS  ", "", &status);
 
-  if(     img[im].unit==0)
-    scale=0.5*(CLIGHT/img[im].freq)*(CLIGHT/img[im].freq)/KBOLTZ; 
-  else if(img[im].unit==1)
+  if(     img[im].imgunits[unit]==0)
+    scale=0.5*(CLIGHT/img[im].freq)*(CLIGHT/img[im].freq)/KBOLTZ;
+  else if(img[im].imgunits[unit]==1)
     scale=1e26*img[im].imgres*img[im].imgres;
-  else if(img[im].unit==2)
+  else if(img[im].imgunits[unit]==2)
     scale=1.0;
-  else if(img[im].unit==3) {
+  else if(img[im].imgunits[unit]==3) {
     ru3 = img[im].distance/1.975e13;
     scale=4.*PI*ru3*ru3*img[im].freq*img[im].imgres*img[im].imgres;
   }
-  else if(img[im].unit!=4) {
+  else if(img[im].imgunits[unit]==5){
+    scale = 1./AU;
+  }
+  else if(img[im].imgunits[unit]!=4) {
     if(!silent) bail_out("Image unit number invalid");
     exit(0);
   }
@@ -123,10 +147,12 @@ write3Dfits(int im, configInfo *par, imageInfo *img){
       for(px=0;px<img[im].pxls;px++){
         ppi = py*img[im].pxls + px;
 
-        if(img[im].unit>-1 && img[im].unit<4)
+        if(img[im].imgunits[unit]>-1 && img[im].imgunits[unit]<4)
           row[px]=(float) img[im].pixel[ppi].intense[ichan]*scale;
-        else if(img[im].unit==4)
+        else if(img[im].imgunits[unit]==4)
           row[px]=(float) img[im].pixel[ppi].tau[ichan];
+        else if(img[im].imgunits[unit]==5)
+            row[px]=(float) img[im].pixel[ppi].numRays;
         else {
           if(!silent) bail_out("Image unit number invalid");
           exit(0);
@@ -150,7 +176,7 @@ write3Dfits(int im, configInfo *par, imageInfo *img){
 }
 
 void 
-write2Dfits(int im, configInfo *par, imageInfo *img){
+write2Dfits(int im, int unit, configInfo *par, imageInfo *img){
   double bscale,bzero,epoch,lonpole,equinox,restfreq;
   double cdelt1,crpix1,crval1,cdelt2,crpix2,crval2;
   double ru3,scale;
@@ -169,7 +195,7 @@ write2Dfits(int im, configInfo *par, imageInfo *img){
 
   naxes[0]=img[im].pxls;
   naxes[1]=img[im].pxls;
-  if(img[im].unit!=5 && (img[im].doline==1 || (img[im].doline==0 && par->polarization))){
+  if(img[im].imgunits[unit]!=5 && (img[im].doline==1 || (img[im].doline==0 && par->polarization))){
     if(!silent) bail_out("You need to write a 3D FITS output in this case");
     exit(0);
   }
@@ -218,30 +244,32 @@ write2Dfits(int im, configInfo *par, imageInfo *img){
   fits_write_key(fptr, TSTRING, "CUNIT2  ", &"DEG     ",    "", &status);
   fits_write_key(fptr, TDOUBLE, "BSCALE  ", &bscale,        "", &status);
   fits_write_key(fptr, TDOUBLE, "BZERO   ", &bzero,         "", &status);
-  if(img[im].unit==0) fits_write_key(fptr, TSTRING, "BUNIT", &"K       ", "", &status);
-  if(img[im].unit==1) fits_write_key(fptr, TSTRING, "BUNIT", &"JY/PIXEL", "", &status);
-  if(img[im].unit==2) fits_write_key(fptr, TSTRING, "BUNIT", &"WM2HZSR ", "", &status);
-  if(img[im].unit==3) fits_write_key(fptr, TSTRING, "BUNIT", &"Lsun/PX ", "", &status);
-  if(img[im].unit==4) fits_write_key(fptr, TSTRING, "BUNIT", &"        ", "", &status);
-  if(img[im].unit==5) fits_write_key(fptr, TSTRING, "BUNIT", &"N_RAYS  ", "", &status);
+  if(img[im].imgunits[unit]==0) fits_write_key(fptr, TSTRING, "BUNIT", &"K       ", "", &status);
+  if(img[im].imgunits[unit]==1) fits_write_key(fptr, TSTRING, "BUNIT", &"JY/PIXEL", "", &status);
+  if(img[im].imgunits[unit]==2) fits_write_key(fptr, TSTRING, "BUNIT", &"WM2HZSR ", "", &status);
+  if(img[im].imgunits[unit]==3) fits_write_key(fptr, TSTRING, "BUNIT", &"Lsun/PX ", "", &status);
+  if(img[im].imgunits[unit]==4) fits_write_key(fptr, TSTRING, "BUNIT", &"        ", "", &status);
+  if(img[im].imgunits[unit]==5) fits_write_key(fptr, TSTRING, "BUNIT", &"N_RAYS  ", "", &status);
 
-  if(     img[im].unit==0)
-    scale=0.5*(CLIGHT/img[im].freq)*(CLIGHT/img[im].freq)/KBOLTZ; 
-
-  else if(img[im].unit==1)
+  if(     img[im].imgunits[unit]==0)
+    scale=0.5*(CLIGHT/img[im].freq)*(CLIGHT/img[im].freq)/KBOLTZ;
+  else if(img[im].imgunits[unit]==1)
     scale=1e26*img[im].imgres*img[im].imgres;
-  else if(img[im].unit==2)
+  else if(img[im].imgunits[unit]==2)
     scale=1.0;
-  else if(img[im].unit==3) {
+  else if(img[im].imgunits[unit]==3) {
     ru3 = img[im].distance/1.975e13;
     scale=4.*PI*ru3*ru3*img[im].freq*img[im].imgres*img[im].imgres;
   }
-  else if(img[im].unit!=4 && img[im].unit!=5) {
+  else if(img[im].imgunits[unit]==5){
+    scale = 1./AU;
+  }
+  else if(img[im].imgunits[unit]!=4) {
     if(!silent) bail_out("Image unit number invalid");
     exit(0);
   }
 
-  if(img[im].unit<5)
+  if(img[im].imgunits[unit]<5)
     minVal = eps;
   else
     minVal = 0.0;
@@ -251,11 +279,11 @@ write2Dfits(int im, configInfo *par, imageInfo *img){
     for(px=0;px<img[im].pxls;px++){
       ppi = py*img[im].pxls + px;
 
-      if(img[im].unit>-1 && img[im].unit<4)
+      if(img[im].imgunits[unit]>-1 && img[im].imgunits[unit]<4)
         row[px]=(float) img[im].pixel[ppi].intense[0]*scale;
-      else if(img[im].unit==4)
+      else if(img[im].imgunits[unit]==4)
         row[px]=(float) img[im].pixel[ppi].tau[0];
-      else if(img[im].unit==5)
+      else if(img[im].imgunits[unit]==5)
         row[px]=(float) img[im].pixel[ppi].numRays;
       else {
         if(!silent) bail_out("Image unit number invalid");

--- a/src/writefits.c
+++ b/src/writefits.c
@@ -50,7 +50,7 @@ char *removeFilenameExtension(char* inStr, char extensionChar, char pathSeparato
 }
 
 void insertUnitStrInFilename(char *img_filename_root, configInfo *par, imageInfo *img, const int im, const int unit_index){
-  char *temp_filename, message[STR_LEN_0];
+  char *temp_filename, *temp_extensionless_filename, message[STR_LEN_0];
   static char* unit_names[] = {"Kelvin", "Jansky-per-px", "SI", "LSun-per-px", "Tau", "#Rays"};
   char *ext;
 
@@ -65,11 +65,13 @@ void insertUnitStrInFilename(char *img_filename_root, configInfo *par, imageInfo
   /* Extract filename extension */
   ext = strrchr(img_filename_root, '.');
   if (!ext) {
-    /* Set to default if no filename extension was extracted */
-    ext = ".fits";
+    /* Set to blank string if no filename extension was extracted */
+    ext = "";
   } else {
     /* Remove extension from temporary filename */
-    temp_filename = removeFilenameExtension(temp_filename, '.', '/');
+      temp_extensionless_filename = removeFilenameExtension(temp_filename, '.', '/');
+      strcpy(temp_filename, temp_extensionless_filename);
+      free(temp_extensionless_filename);
   }
   /* Append unit name to temporary filename */
   strcat(temp_filename, "_");


### PR DESCRIPTION
I have removed the need for multiple raytracings when only the image unit is changed between multiple image outputs. Now the user can set a delimiter (space, comma, colon or underscore all accepted) separated string of the units required, where the unit numbers-to-type are the same as before. The unit name and file extension are then automatically appended to img[].filename.