### PR TITLE
Several changes to checks of mandatory functions.

### DIFF
--- a/src/frees.c
+++ b/src/frees.c
@@ -152,6 +152,7 @@ freeSomeGridFields(const unsigned int numPoints, const unsigned short numSpecies
 
   if(gp != NULL){
     for(i_u=0;i_u<numPoints;i_u++){
+      free(gp[i_u].w);
       gp[i_u].w    = NULL;
       free(gp[i_u].abun);
       gp[i_u].abun = NULL;

--- a/src/grid2fits.c
+++ b/src/grid2fits.c
@@ -1614,4 +1614,22 @@ long naxes[2];
   processFitsError(status);
 }
 
+/*....................................................................*/
+int
+countDensityColsFITS(char *inFileName){
+  int numDensities;
+  fitsfile *fptr=NULL;
+  int status=0;
+
+  fptr = openFITSFileForRead(inFileName);
+
+  fits_movnam_hdu(fptr, BINARY_TBL, "GRID", 0, &status);
+  processFitsError(status);
+
+  numDensities = countColsBasePlusInt(fptr, "DENSITY");
+
+  closeFITSFile(fptr);
+
+  return numDensities;
+}
 

--- a/src/grid2fits.h
+++ b/src/grid2fits.h
@@ -37,6 +37,7 @@ void	writeGridExtToFits(fitsfile*, struct gridInfoType, struct grid*, unsigned i
 void	writeLinksExtToFits(fitsfile*, struct gridInfoType, struct linkType*);
 void	writeNnIndicesExtToFits(fitsfile*, struct gridInfoType, struct linkType**);//, struct linkType*);
 void	writePopsExtToFits(fitsfile*, struct gridInfoType, const unsigned short, struct grid*);
+int	countDensityColsFITS(char *inFileName);
 
 #endif /* GRID2FITS_H */
 

--- a/src/gridio.c
+++ b/src/gridio.c
@@ -851,5 +851,17 @@ NOTE that gp should not be allocated before this routine is called.
   return 0;
 }
 
+/*....................................................................*/
+int
+countDensityCols(char *inFileName, const int fileFormatI, int *numDensities){
+  int status=0;
 
+  if(fileFormatI==lime_FITS){
+    *numDensities = countDensityColsFITS(inFileName);
+  }else{
+    status = 1;
+  }
+
+  return status;
+}
 

--- a/src/gridio.h
+++ b/src/gridio.h
@@ -32,6 +32,7 @@ struct gridInfoType{
 
 int	readGrid(char*, const int, struct gridInfoType*, struct keywordType*, const int, struct grid**, char***, int*, int*);
 int	writeGrid(char*, const int, struct gridInfoType, struct keywordType*, const int, struct grid*, char**, const int);
+int	countDensityCols(char*, const int, int*);
 
 #endif /* GRIDIO_H */
 

--- a/src/lime.h
+++ b/src/lime.h
@@ -152,9 +152,9 @@ typedef struct {
   char *restart;
   char *dust;
   int sampling,lte_only,init_lte,antialias,polarization,nThreads,numDims;
-  int nLineImages, nContImages;
+  int nLineImages,nContImages;
   char **moldatfile;
-  _Bool writeGridAtStage[NUM_GRID_STAGES],resetRNG;
+  _Bool writeGridAtStage[NUM_GRID_STAGES],resetRNG,doInterpolateVels;
   char *gridInFile,**gridOutFiles;
   int dataFlags,nSolveIters;
   double (*gridDensMaxLoc)[DIM], *gridDensMaxValues;

--- a/src/raythrucells.c
+++ b/src/raythrucells.c
@@ -615,8 +615,8 @@ and filled as
   const int numFaces=numDims+1, maxNumEntryFaces=100;
   int numEntryFaces,fi,entryFis[maxNumEntryFaces],i,status;
   faceType face;
-  unsigned long dci, entryDcis[maxNumEntryFaces];
-  intersectType intcpt, entryIntcpts[maxNumEntryFaces];
+  unsigned long dci,entryDcis[maxNumEntryFaces];
+  intersectType intcpt,entryIntcpts[maxNumEntryFaces];
   _Bool *cellVisited=NULL;
 
   /* Choose a set of starting faces by testing all the 'external' faces of cells which have some. */

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -742,7 +742,7 @@ We're going to calculate the line amplitude increment per segment for the 2nd-or
       projVelOld = doSegmentInterpScalar(projRayVels, 0);
       projVel2ndDeriv = (projRayVels[0] + projRayVels[1] - 2.0*projRayVels[2])*4.0; /* The times 4 is actually a divide by deltaX^2, because in this case deltaX is nominally 0.5, i.e. half-way across the path through the cell. */
       projVelOffset = -projVel2ndDeriv*oneOnNumSegments*oneOnNumSegments/6.0;
-    } /* end if(img[im].doline) */
+    } /* end if(img[im].doline) && img[im].doInterpolateVels */
 
     /* At this point we have interpolated all the values of interest to both the entry and exit points of the cell. Now we break the path between entry and exit into several segments and calculate all these values at the midpoint of each segment.
 


### PR DESCRIPTION
Checks made on the presence of the five 'mandatory' functions density(), temperature(), abundance(), doppler() and velocity(), are now performed more intelligently. A test for divide-by-zero is also done on the returns of these functions and a warning issued.

This addresses #201 and replaces (or invalidates) #198. Detailed changes are as follows:

  - In aux.c:parseInput() the presence of a par->gridInFile is tested, and if one has been supplied, the number of density columns is read from this and par->numDensities is set to this value.

  - In grid.c:readOrBuildGrid(), all tests for the presence of mandatory functions are now (also) done before smoothing. This is so, if one is missing, the user won't have to wait until the smoothing is done before finding out.

  - All tests of mandatory functions do so at the origin of coordinates. If the user has allowed a singularity at this location (for example if the function divides by some power of radius), a warning is issued. LIME should not be trying to second-guess where the user might have left a singularity: it should be the user's responsibility to avoid building such into their functions.

  - In grid.c:readOrBuildGrid(), if par->nLineImages==0, only the density() and temperature() functions are required when there are no file values.

  - New element doInterpolateVels of struct configInfo is set if any of the images has this flag set.

  - Restored free of gp[].w in freeSomeGridFields() which had been mistakenly deleted.