### PR TITLE
Added new semi-mandatory function molNumDensity().

### DIFF
--- a/example/model.c
+++ b/example/model.c
@@ -136,7 +136,7 @@ density(double x, double y, double z, double *density){
    * Define variable for radial coordinate
    */
   double r, rToUse;
-  const double rMin = 0.5*AU; /* This cutoff should be chosen smaller than par->minScale but greater than zero (to avoid a singularity at the origin). */
+  const double rMin = 0.7*AU; /* This cutoff should be chosen smaller than par->minScale but greater than zero (to avoid a singularity at the origin). */
 
   /*
    * Calculate radial distance from origin

--- a/src/defaults.c
+++ b/src/defaults.c
@@ -12,31 +12,36 @@
 
 
 void __attribute__((weak))
-    density(double x, double y, double z, double *density){
-      if(!silent) bail_out("Density is not defined in model.c but is needed by LIME!");
+    density(double x, double y, double z, double *dummy){
+      if(!silent) bail_out("Gas number density is not defined in model.c but is needed by LIME!");
       exit(1);
     }
 
 void __attribute__((weak))
-    temperature(double x, double y, double z, double *temperature){
+    temperature(double x, double y, double z, double *dummy){
       if(!silent) bail_out("Temperature is not defined in model.c but is needed by LIME!");
       exit(1);
     }
 
+/* One of the following two must be defined by the user: */
 void __attribute__((weak))
-    abundance(double x, double y, double z, double *abundance){
-      if(!silent) bail_out("Abundance is not defined in model.c but is needed by LIME!");
-      exit(1);
+    abundance(double x, double y, double z, double *dummy){
+      dummy[0] = -1.0;
     }
 
 void __attribute__((weak))
-    doppler(double x, double y, double z, double *doppler){
+    molNumDensity(double x, double y, double z, double *dummy){
+      dummy[0] = -1.0;
+    }
+
+void __attribute__((weak))
+    doppler(double x, double y, double z, double *dummy){
       if(!silent) bail_out("Doppler velocity is not defined in model.c but is needed by LIME!");
       exit(1);
     }
 
 void __attribute__((weak))
-    velocity(double x, double y, double z, double *vel){
+    velocity(double x, double y, double z, double *dummy){
       if(!silent) bail_out("Velocity field is not defined in model.c but is needed by LIME!");
       exit(1);
     }

--- a/src/frees.c
+++ b/src/frees.c
@@ -66,7 +66,6 @@ freeGrid(const unsigned int numPoints, const unsigned short numSpecies\
       free(gp[i_u].neigh);
       free(gp[i_u].w);
       free(gp[i_u].dens);
-      free(gp[i_u].abun);
       free(gp[i_u].ds);
       freePopulation(numSpecies, gp[i_u].mol);
     }
@@ -171,8 +170,6 @@ freeSomeGridFields(const unsigned int numPoints, const unsigned short numSpecies
     for(i_u=0;i_u<numPoints;i_u++){
       free(gp[i_u].w);
       gp[i_u].w    = NULL;
-      free(gp[i_u].abun);
-      gp[i_u].abun = NULL;
       free(gp[i_u].ds);
       gp[i_u].ds   = NULL;
 

--- a/src/grid2fits.c
+++ b/src/grid2fits.c
@@ -8,7 +8,7 @@
 TODOS (some day):
 	- Change the type of g[i].id to unsigned int.
 	- Change the type of g[i].numNeigh to unsigned short.
-	- Change g[i].t, g[i].dopb and g[i].abun to float.
+	- Change g[i].t, g[i].dopb and g[i].mol[si].abun to float.
 	- Vector columns in defineGridExtColumns()?
 */
 
@@ -563,7 +563,7 @@ Ok we have a bit of a tricky situation here in that the number of columns we wri
       }
 
       for(i_ui=0;i_ui<totalNumGridPoints;i_ui++)
-        abunm[i_ui] = (float)gp[i_ui].abun[i_us];
+        abunm[i_ui] = (float)gp[i_ui].mol[i_us].abun;
       fits_write_col(fptr, colDataTypes[colI-1], colI, firstRow, firstElem, (LONGLONG)totalNumGridPoints, abunm, &status);
       processFitsError(status);
     }
@@ -990,7 +990,7 @@ If a COLLPARn keywords are found in the GRID extension header then collPartNames
     return; /* I.e. with dataFlags left unchanged. */
   }
 
-  mallocAndSetDefaultGrid(gp, (unsigned int)numGridCells);
+  mallocAndSetDefaultGrid(gp, (size_t)numGridCells, 0);
 
   /* Read the columns.
   */
@@ -1152,10 +1152,6 @@ If a COLLPARn keywords are found in the GRID extension header then collPartNames
   */
   gridInfoRead->nSpecies = (unsigned short)countColsBasePlusInt(fptr, "ABUNMOL");
   if(gridInfoRead->nSpecies > 0){
-    for(i_LL=0;i_LL<numGridCells;i_LL++) {
-      (*gp)[i_LL].abun = malloc(sizeof(double)*gridInfoRead->nSpecies);
-    }
-
     /* Read the ABUNMOL columns:
     */
     abunm = malloc(sizeof(*abunm)*numGridCells);
@@ -1168,7 +1164,7 @@ If a COLLPARn keywords are found in the GRID extension header then collPartNames
       processFitsError(status);
 
       for(i_LL=0;i_LL<numGridCells;i_LL++) {
-        (*gp)[i_LL].abun[i_us] = (double)abunm[i_LL];
+        (*gp)[i_LL].mol[i_us].abun = (double)abunm[i_LL];
       }
     }
     free(abunm);

--- a/src/grid2fits.h
+++ b/src/grid2fits.h
@@ -35,7 +35,7 @@ fitsfile *openFITSFileForWrite(char*);
 void	writeKeywordsToFits(lime_fptr*, struct keywordType*, const int);
 void	writeGridExtToFits(fitsfile*, struct gridInfoType, struct grid*, unsigned int*, char**, const int);
 void	writeLinksExtToFits(fitsfile*, struct gridInfoType, struct linkType*);
-void	writeNnIndicesExtToFits(fitsfile*, struct gridInfoType, struct linkType**);//, struct linkType*);
+void	writeNnIndicesExtToFits(fitsfile*, struct gridInfoType, struct linkType**);
 void	writePopsExtToFits(fitsfile*, struct gridInfoType, const unsigned short, struct grid*);
 int	countDensityColsFITS(char *inFileName);
 

--- a/src/inpars.h
+++ b/src/inpars.h
@@ -24,7 +24,7 @@ typedef struct {
   char **moldatfile,**collPartNames;
   char *gridInFile,**gridOutFiles;
   int nSolveIters;
-  double (*gridDensMaxLoc)[DIM], *gridDensMaxValues;
+  double (*gridDensMaxLoc)[DIM],*gridDensMaxValues;
   _Bool resetRNG;
 } inputPars;
 

--- a/src/lime.h
+++ b/src/lime.h
@@ -154,7 +154,7 @@ typedef struct {
   int sampling,lte_only,init_lte,antialias,polarization,nThreads,numDims;
   int nLineImages,nContImages;
   char **moldatfile,**collPartNames;
-  _Bool writeGridAtStage[NUM_GRID_STAGES],resetRNG,doInterpolateVels;
+  _Bool writeGridAtStage[NUM_GRID_STAGES],resetRNG,doInterpolateVels,useAbun;
   char *gridInFile,**gridOutFiles;
   int dataFlags,nSolveIters;
   double (*gridDensMaxLoc)[DIM],*gridDensMaxValues;
@@ -198,7 +198,7 @@ struct continuumLine{
 
 struct populations {
   double *pops,*specNumDens;
-  double dopb, binv, nmol;
+  double dopb,binv,nmol,abun;
   struct rates *partner;
   struct continuumLine *cont;
 };
@@ -215,7 +215,7 @@ struct grid {
   int sink;
   int nphot;
   int conv;
-  double *dens,t[2],*abun, dopb_turb;
+  double *dens,t[2],dopb_turb;
   double *ds;
   struct populations *mol;
   struct continuumLine cont;
@@ -295,6 +295,7 @@ extern int silent;
 void density(double,double,double,double *);
 void temperature(double,double,double,double *);
 void abundance(double,double,double,double *);
+void molNumDensity(double,double,double,double *);
 void doppler(double,double,double, double *);
 void velocity(double,double,double,double *);
 void magfield(double,double,double,double *);
@@ -315,7 +316,7 @@ void	calcFastExpRange(const int, const int, int*, int*, int*);
 void	calcGridCollRates(configInfo*, molData*, struct grid*);
 void	calcGridContDustOpacity(configInfo*, const double, double*, double*, const int, struct grid*);
 void	calcGridLinesDustOpacity(configInfo*, molData*, double*, double*, const int, struct grid*);
-void	calcGridMolDensities(configInfo*, struct grid*);
+void	calcGridMolDensities(configInfo*, struct grid**);
 void	calcGridMolDoppler(configInfo*, molData*, struct grid*);
 void	calcGridMolSpecNumDens(configInfo*, molData*, struct grid*);
 void	calcInterpCoeffs(configInfo*, struct grid*);
@@ -362,7 +363,7 @@ void	levelPops(molData*, configInfo*, struct grid*, int*, double*, double*, cons
 void	lineBlend(molData*, configInfo*, struct blendInfo*);
 void	LTE(configInfo*, struct grid*, molData*);
 void	lteOnePoint(molData*, const int, const double, double*);
-void	mallocAndSetDefaultGrid(struct grid**, const unsigned int);
+void	mallocAndSetDefaultGrid(struct grid**, const size_t, const size_t);
 void	molInit(configInfo*, molData*);
 void	openSocket(char*);
 void	parseInput(inputPars, image*, const int, configInfo*, imageInfo**, molData**);
@@ -382,6 +383,7 @@ void	readOrBuildGrid(configInfo*, struct grid**);
 void	readUserInput(inputPars*, imageInfo**, int*, int*);
 unsigned long reorderGrid(const unsigned long, struct grid*);
 void	report(int, configInfo*, struct grid*);
+void	reportInfsAtOrigin(const int, const double*, const char*);
 void	setUpConfig(configInfo*, imageInfo**, molData**);
 void	setUpDensityAux(configInfo*, int*, const int);
 void	smooth(configInfo*, struct grid*);

--- a/src/popsin.c
+++ b/src/popsin.c
@@ -63,43 +63,25 @@ popsin(configInfo *par, struct grid **gp, molData **md, int *popsdone){
     fread(&dummy, sizeof(double),   1,fp);
   }
 
-  *gp=malloc(sizeof(struct grid)*par->ncell);
-
   for(i=0;i<par->ncell;i++){
-    (*gp)[i].v1 = NULL;
-    (*gp)[i].v2 = NULL;
-    (*gp)[i].v3 = NULL;
-    (*gp)[i].dens = NULL;
-    (*gp)[i].abun = NULL;
-    (*gp)[i].dir = NULL;
-    (*gp)[i].neigh = NULL;
-    (*gp)[i].w = NULL;
-    (*gp)[i].ds = NULL;
     fread(&(*gp)[i].id, sizeof (*gp)[i].id, 1, fp);
     fread(&(*gp)[i].x, sizeof (*gp)[i].x, 1, fp);
     fread(&(*gp)[i].vel, sizeof (*gp)[i].vel, 1, fp);
     fread(&(*gp)[i].sink, sizeof (*gp)[i].sink, 1, fp);
-    (*gp)[i].mol=malloc(par->nSpecies*sizeof(struct populations));
     for(j=0;j<par->nSpecies;j++)
       fread(&(*gp)[i].mol[j].nmol, sizeof(double), 1, fp);
     fread(&(*gp)[i].dopb_turb, sizeof (*gp)[i].dopb_turb, 1, fp);
     for(j=0;j<par->nSpecies;j++){
       (*gp)[i].mol[j].pops=malloc(sizeof(double)*(*md)[j].nlev);
       for(k=0;k<(*md)[j].nlev;k++) fread(&(*gp)[i].mol[j].pops[k], sizeof(double), 1, fp);
-      (*gp)[i].mol[j].cont = NULL;
       for(k=0;k<(*md)[j].nline;k++) fread(&dummy, sizeof(double), 1, fp);
       for(k=0;k<(*md)[j].nline;k++) fread(&dummy, sizeof(double), 1, fp);
       fread(&(*gp)[i].mol[j].dopb,sizeof(double), 1, fp);
       fread(&(*gp)[i].mol[j].binv,sizeof(double), 1, fp);
-      (*gp)[i].mol[j].partner=NULL;
     }
     fread(&dummy, sizeof(double), 1, fp);
     fread(&dummy, sizeof(double), 1, fp);
     fread(&dummy, sizeof(double), 1, fp);
-
-    (*gp)[i].B[0] = 0.0;
-    (*gp)[i].B[1] = 0.0;
-    (*gp)[i].B[2] = 0.0;
   }
   fclose(fp);
 

--- a/src/popsout.c
+++ b/src/popsout.c
@@ -109,7 +109,7 @@ binpopsout(configInfo *par, struct grid *gp, molData *md){
     }
     fwrite(&gp[i].dens[0], sizeof(double), 1, fp);
     fwrite(&gp[i].t[0],    sizeof(double), 1, fp);
-    fwrite(&gp[i].abun[0], sizeof(double), 1, fp);
+    fwrite(&gp[i].mol[0].abun, sizeof(double), 1, fp);
   }
 
   fclose(fp);

--- a/src/predefgrid.c
+++ b/src/predefgrid.c
@@ -10,7 +10,7 @@
 #include "lime.h"
 
 void
-predefinedGrid(configInfo *par, struct grid *g){
+predefinedGrid(configInfo *par, struct grid *gp){
   FILE *fp;
   int i,j;
   double x,y,z,scale;
@@ -28,33 +28,33 @@ predefinedGrid(configInfo *par, struct grid *g){
   par->ncell=par->pIntensity+par->sinkPoints;
 
   for(i=0;i<par->pIntensity;i++){
-    //    fscanf(fp,"%d %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf\n", &g[i].id, &g[i].x[0], &g[i].x[1], &g[i].x[2],  &g[i].dens[0], &g[i].t[0], &abun, &g[i].dopb_turb, &g[i].vel[0], &g[i].vel[1], &g[i].vel[2]);
-    //    fscanf(fp,"%d %lf %lf %lf %lf %lf %lf %lf\n", &g[i].id, &g[i].x[0], &g[i].x[1], &g[i].x[2],  &g[i].dens[0], &g[i].t[0], &abun, &g[i].dopb_turb);
-    int nRead = fscanf(fp,"%d %lf %lf %lf %lf %lf %lf %lf %lf\n", &g[i].id, &g[i].x[0], &g[i].x[1], &g[i].x[2],  &g[i].dens[0], &g[i].t[0], &g[i].vel[0], &g[i].vel[1], &g[i].vel[2]);
-    if( nRead != 9 || g[i].id < 0 || g[i].id > par->ncell)
+    //    fscanf(fp,"%d %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf\n", &gp[i].id, &gp[i].x[0], &gp[i].x[1], &gp[i].x[2],  &gp[i].dens[0], &gp[i].t[0], &abun, &gp[i].dopb_turb, &gp[i].vel[0], &gp[i].vel[1], &gp[i].vel[2]);
+    //    fscanf(fp,"%d %lf %lf %lf %lf %lf %lf %lf\n", &gp[i].id, &gp[i].x[0], &gp[i].x[1], &gp[i].x[2],  &gp[i].dens[0], &gp[i].t[0], &abun, &gp[i].dopb_turb);
+    int nRead = fscanf(fp,"%d %lf %lf %lf %lf %lf %lf %lf %lf\n", &gp[i].id, &gp[i].x[0], &gp[i].x[1], &gp[i].x[2],  &gp[i].dens[0], &gp[i].t[0], &gp[i].vel[0], &gp[i].vel[1], &gp[i].vel[2]);
+    if( nRead != 9 || gp[i].id < 0 || gp[i].id > par->ncell)
       {
         if(!silent) bail_out("Reading Grid File error");
         exit(0);
       }
 
-    g[i].dopb_turb=200;
-    g[i].abun[0]=1e-9;
+    gp[i].dopb_turb=200;
+    gp[i].mol[0].abun=1e-9;
 
-    g[i].sink=0;
-    g[i].t[1]=g[i].t[0];
-    g[i].mol[0].nmol=g[i].abun[0]*g[i].dens[0];
-    g[i].B[0]=0.0;
-    g[i].B[1]=0.0;
-    g[i].B[2]=0.0;
+    gp[i].sink=0;
+    gp[i].t[1]=gp[i].t[0];
+    gp[i].mol[0].nmol=gp[i].mol[0].abun*gp[i].dens[0];
+    gp[i].B[0]=0.0;
+    gp[i].B[1]=0.0;
+    gp[i].B[2]=0.0;
 
     /* This next step needs to be done, even though it looks stupid */
-    g[i].dir=malloc(sizeof(point)*1);
-    g[i].ds =malloc(sizeof(double)*1);
-    g[i].neigh =malloc(sizeof(struct grid *)*1);
+    gp[i].dir=malloc(sizeof(point)*1);
+    gp[i].ds =malloc(sizeof(double)*1);
+    gp[i].neigh =malloc(sizeof(struct grid *)*1);
     if(!silent) progressbar((double) i/((double)par->pIntensity-1), 4);	
   }
 
-  checkGridDensities(par, g);
+  checkGridDensities(par, gp);
 
   for(i=par->pIntensity;i<par->ncell;i++){
     x=2*gsl_rng_uniform(ran)-1.;
@@ -62,37 +62,37 @@ predefinedGrid(configInfo *par, struct grid *g){
     z=2*gsl_rng_uniform(ran)-1.;
     if(x*x+y*y+z*z<1){
       scale=par->radius*sqrt(1/(x*x+y*y+z*z));
-      g[i].id=i;
-      g[i].x[0]=scale*x;
-      g[i].x[1]=scale*y;
-      g[i].x[2]=scale*z;
-      g[i].sink=1;
-      g[i].abun[0]=0;
-      g[i].dens[0]=1e-30;
-      g[i].mol[0].nmol=0.0; /* Just to give it a value. */
-      g[i].t[0]=par->tcmb;
-      g[i].t[1]=par->tcmb;
-      g[i].B[0]=0.0;
-      g[i].B[1]=0.0;
-      g[i].B[2]=0.0;
-      g[i].dopb_turb=0.;
-      for(j=0;j<DIM;j++) g[i].vel[j]=0.;
+      gp[i].id=i;
+      gp[i].x[0]=scale*x;
+      gp[i].x[1]=scale*y;
+      gp[i].x[2]=scale*z;
+      gp[i].sink=1;
+      gp[i].mol[0].abun=0.0; /* Just to give it a value. */
+      gp[i].dens[0]=1e-30;
+      gp[i].mol[0].nmol=0.0; /* Just to give it a value. */
+      gp[i].t[0]=par->tcmb;
+      gp[i].t[1]=par->tcmb;
+      gp[i].B[0]=0.0;
+      gp[i].B[1]=0.0;
+      gp[i].B[2]=0.0;
+      gp[i].dopb_turb=0.;
+      for(j=0;j<DIM;j++) gp[i].vel[j]=0.;
     } else i--;
   }
   fclose(fp);
 
-  delaunay(DIM, g, (unsigned long)par->ncell, 0, 1, &dc, &numCells);
+  delaunay(DIM, gp, (unsigned long)par->ncell, 0, 1, &dc, &numCells);
 
   /* We just asked delaunay() to flag any grid points with IDs lower than par->pIntensity (which means their distances from model centre are less than the model radius) but which are nevertheless found to be sink points by virtue of the geometry of the mesh of Delaunay cells. Now we need to reshuffle the list of grid points, then reset par->pIntensity, such that all the non-sink points still have IDs lower than par->pIntensity.
   */ 
-  nExtraSinks = reorderGrid((unsigned long)par->ncell, g);
+  nExtraSinks = reorderGrid((unsigned long)par->ncell, gp);
   par->pIntensity -= nExtraSinks;
   par->sinkPoints += nExtraSinks;
 
-  distCalc(par,g);
-  //  getArea(par,g, ran);
-  //  getMass(par,g, ran);
-  getVelocities_pregrid(par,g);
+  distCalc(par,gp);
+  //  getArea(par,gp, ran);
+  //  getMass(par,gp, ran);
+  getVelocities_pregrid(par,gp);
 
   par->dataFlags |= (1 << DS_bit_x);
   par->dataFlags |= (1 << DS_bit_neighbours);
@@ -106,7 +106,7 @@ predefinedGrid(configInfo *par, struct grid *g){
 
 //**** should fill in any missing info via the appropriate function calls.
 
-  if(par->gridfile) write_VTK_unstructured_Points(par, g);
+  if(par->gridfile) write_VTK_unstructured_Points(par, gp);
   gsl_rng_free(ran);
   free(dc);
 


### PR DESCRIPTION
This closes #186.

Some rearrangements of struct grid and when parts of it are malloc'd have been required, as follows.
  - 'abun' is no longer a pointer attribute of struct grid but a scalar attribute of struct populations.

  - mallocAndSetDefaultGrid() now also takes the number of species and performs the malloc of struct grid attribute 'mol' which was previously done in main() after the call to molInit().

  - popsin() no longer mallocs the grid struct, this is done beforehand via mallocAndSetDefaultGrid().

  - The default abundance() function now no longer throws an exception, it returns -1 (which is a non-physical value). The absence of a user-supplied version of this function is now tested by comparing the returned value with 0. Removal of the exception was done because the user may now supply either abundance() or molNumDensity(), thus abundance() is no longer strictly mandatory.

  - Attribute 'useAbun' added to struct configInfo. This is used to flag when we need to call calcGridMolDensities() in main().

Some small additional, unrelated changes:
  - Grid struct element B[3] entries are now initialized to 0 rather than -1. This for 2 reasons: firstly -1 could be a physical value (since these values are the Cartesian components of a vector) and secondly because there is in fact no B<0 test anywhere in LIME. Thus 0 is probably safer.

  - The task now exits with an error if a singularity is found at the origin for the gridDensity() function.