### PR TITLE
Fix for reading in abundance values with gridInFile.

### DIFF
--- a/src/grid2fits.c
+++ b/src/grid2fits.c
@@ -990,7 +990,11 @@ If a COLLPARn keywords are found in the GRID extension header then collPartNames
     return; /* I.e. with dataFlags left unchanged. */
   }
 
-  mallocAndSetDefaultGrid(gp, (size_t)numGridCells, 0);
+  /* Count the numbers of ABUNMOL columns here so that, if appropriate, we can malloc 'gp' molecular data array
+     with this call to mallocAndSetDefaultGrid (only happens if nSpecies > 0)
+  */
+  gridInfoRead->nSpecies = (unsigned short)countColsBasePlusInt(fptr, "ABUNMOL");
+  mallocAndSetDefaultGrid(gp, (size_t)numGridCells, gridInfoRead->nSpecies);
 
   /* Read the columns.
   */
@@ -1148,9 +1152,6 @@ If a COLLPARn keywords are found in the GRID extension header then collPartNames
     (*dataFlags) |= (1 << DS_bit_density);
   }
 
-  /* Count the numbers of ABUNMOLm columns:
-  */
-  gridInfoRead->nSpecies = (unsigned short)countColsBasePlusInt(fptr, "ABUNMOL");
   if(gridInfoRead->nSpecies > 0){
     /* Read the ABUNMOL columns:
     */


### PR DESCRIPTION
In grid2fits.c: readGridExtFromFits() the grid is malloc'd initially with a call to mallocAndSetDefaultGrid()
using nSpecies=0. However, this means that (*gp).[i].mol is never malloc'd and therefore later when
abundances are read in (block starting line 1155) LIME segfaults. This is a simple fix that moves the nSpecies determination to before the mallocAndSetDefaultGrid() call and passes this as an argument so that (*gp).[i].mol is malloc'd correctly if appropriate. I don't think this breaks anything or causes any unintended behaviour.