### PR TITLE
Add a call to readDummyCollPart to keep file reading in sync.

### DIFF
--- a/src/molinit.c
+++ b/src/molinit.c
@@ -217,9 +217,10 @@ void readMolData(configInfo *par, molData *md, int **allUniqueCollPartIds\
             fscanf(fp,"\n");
           }
         } /* End if(par->lte_only) */
-
         k++;
-      } /* End if CP found in par->collPartIds. */
+      }else{ /* read and discard to keep the file reading in sync */
+        readDummyCollPart(fp, sizeI);
+      }/* End if CP found in par->collPartIds. */
     } /* End loop over collision partners this molecule. */
     numPartsAcceptedThisMol = k;
 


### PR DESCRIPTION
Simple fix to make sure that file reading doesn't go off the rails when there are unused collision partners defined in the molecule data file.