### PR TITLE
Zero images

### DIFF
--- a/doc/usermanual.rst
+++ b/doc/usermanual.rst
@@ -370,7 +370,7 @@ unit). This is currently under development.
 
     (string) par->moldatfile[i] (optional)
 
-Path to the i’th molecular data file. This must be be provided if any line images are specified. It is not read if only continuum images are required.
+Path to the i’th molecular data file. This must be be provided if any line images are specified (or if par->doSolveRTE is set). It is not read if only continuum images are required.
 
 Molecular data files contain the
 energy states, Einstein coefficients, and collisional rates which are
@@ -573,6 +573,14 @@ If this is set non-zero, LIME will use the same random number seeds at the start
 
 The default value is 0.
 
+.. code:: c
+
+    (integer) par->doSolveRTE (optional)
+
+It is now possible to run LIME in two sessions: the first to solve the RTE and save the results to file, the second to read the file and create raytraced images from it. For a session of the first type you should set the number of images you specify via the :ref:`img <images>` parameter to zero, and give a value for one of the elements of :ref:`par->gridOutFiles <grid-io>`; for one of the second type you set :ref:`par->gridInFile <grid-io>` to the name of the file you just wrote, and include >0 image specifications in :ref:`img <images>`. There is a problem however for sessions of the first type: if you eventually want full-spectrum cubes then you will need some way to tell LIME to solve the RTE. In the past LIME has figured out if you want this from the presence of spectrum-type images in your :ref:`img <images>` list. To replace this capability we have added the present parameter. Thus, for first-stage sessions (supposing you choose to run LIME in that way rather than in the previous single-pass style) when you know that you will eventually want spectral cubes, you should set the present parameter. For all other cases it may be ignored.
+
+The default value is 0.
+
 .. _grid-io:
 
 .. code:: c
@@ -592,8 +600,6 @@ This file should conform to the format described in the header of src/grid2fits.
 
 These last two parameters mostly replace the functionality of the older `par->outputfile`, `par->binoutputfile`, `par->pregrid`, `par->restart` parameters. These may be abolished in a future version of LIME. Note that `par->gridfile` is still however of use.
 
-.. _images:
-
 .. code:: c
 
     (string) par->girdatfile[i] (optional)
@@ -604,6 +610,8 @@ rotational levels within vibration bands as in Bensch & Bergin 2004.
 This effect is relevant for cometary coma exposed to solar radiation.
 girdatfile is an array, so a different data file can be used for each radiating
 species.  If this parameter is not supplied the effect will be ignored.
+
+.. _images:
 
 Images
 ~~~~~~

--- a/src/aux.c
+++ b/src/aux.c
@@ -154,6 +154,7 @@ The parameters visible to the user have now been strictly confined to members of
   par->nSolveIters  = inpar.nSolveIters;
   par->traceRayAlgorithm = inpar.traceRayAlgorithm;
   par->resetRNG     = inpar.resetRNG;
+  par->doSolveRTE   = inpar.doSolveRTE;
 
   /* Somewhat more carefully copy over the strings:
   */
@@ -327,26 +328,28 @@ The cutoff will be the value of abs(x) for which the error in the exact expressi
 
   /* Copy over user-set image values to the generic struct:
   */
-  *img = malloc(sizeof(**img)*nImages);
-  for(i=0;i<nImages;i++){
-    (*img)[i].nchan      = inimg[i].nchan;
-    (*img)[i].trans      = inimg[i].trans;
-    (*img)[i].molI       = inimg[i].molI;
-    (*img)[i].velres     = inimg[i].velres;
-    (*img)[i].imgres     = inimg[i].imgres;
-    (*img)[i].pxls       = inimg[i].pxls;
-    copyInparStr(inimg[i].units, &((*img)[i].units));
-    (*img)[i].freq       = inimg[i].freq;
-    (*img)[i].bandwidth  = inimg[i].bandwidth;
-    copyInparStr(inimg[i].filename, &((*img)[i].filename));
-    (*img)[i].source_vel = inimg[i].source_vel;
-    (*img)[i].theta      = inimg[i].theta;
-    (*img)[i].phi        = inimg[i].phi;
-    (*img)[i].incl       = inimg[i].incl;
-    (*img)[i].posang     = inimg[i].posang;
-    (*img)[i].azimuth    = inimg[i].azimuth;
-    (*img)[i].distance   = inimg[i].distance;
-    (*img)[i].doInterpolateVels = inimg[i].doInterpolateVels;
+  if(nImages>0){
+    *img = malloc(sizeof(**img)*nImages);
+    for(i=0;i<nImages;i++){
+      (*img)[i].nchan      = inimg[i].nchan;
+      (*img)[i].trans      = inimg[i].trans;
+      (*img)[i].molI       = inimg[i].molI;
+      (*img)[i].velres     = inimg[i].velres;
+      (*img)[i].imgres     = inimg[i].imgres;
+      (*img)[i].pxls       = inimg[i].pxls;
+      copyInparStr(inimg[i].units, &((*img)[i].units));
+      (*img)[i].freq       = inimg[i].freq;
+      (*img)[i].bandwidth  = inimg[i].bandwidth;
+      copyInparStr(inimg[i].filename, &((*img)[i].filename));
+      (*img)[i].source_vel = inimg[i].source_vel;
+      (*img)[i].theta      = inimg[i].theta;
+      (*img)[i].phi        = inimg[i].phi;
+      (*img)[i].incl       = inimg[i].incl;
+      (*img)[i].posang     = inimg[i].posang;
+      (*img)[i].azimuth    = inimg[i].azimuth;
+      (*img)[i].distance   = inimg[i].distance;
+      (*img)[i].doInterpolateVels = inimg[i].doInterpolateVels;
+    }
   }
 
   /* Allocate pixel space and parse image information.

--- a/src/grid.c
+++ b/src/grid.c
@@ -1052,6 +1052,7 @@ readOrBuildGrid(configInfo *par, struct grid **gp){
   char **collPartNames;
   char message[80];
   treeType tree;
+  const _Bool doMolCalcs = par->doSolveRTE || par->nLineImages>0;
 
   par->dataFlags = 0;
   if(par->gridInFile!=NULL){
@@ -1155,8 +1156,8 @@ readOrBuildGrid(configInfo *par, struct grid **gp){
       if(!silent) warning("You have a singularity at the origin in your temperature() function.");
   }
 
-  par->useAbun = 1; /* This will remain so if the abu values have been read from file. */
-  if(!allBitsSet(par->dataFlags, DS_mask_abundance) && par->nLineImages>0){
+  par->useAbun = 1; /* This will remain so if the abun values have been read from file. */
+  if(!allBitsSet(par->dataFlags, DS_mask_abundance) && doMolCalcs){
     dummyPointer = malloc(sizeof(*dummyPointer)*par->nSpecies);
     abundance(0.0,0.0,0.0,dummyPointer);
     if(dummyPointer[0]<0.0){ /* This is used to flag that the user has supplied no abundance() function. */
@@ -1182,13 +1183,13 @@ readOrBuildGrid(configInfo *par, struct grid **gp){
     free(dummyPointer);
   }
 
-  if(!allBitsSet(par->dataFlags, DS_mask_turb_doppler) && par->nLineImages>0){
+  if(!allBitsSet(par->dataFlags, DS_mask_turb_doppler) && doMolCalcs){
     doppler(0.0,0.0,0.0,&dummyScalar);	
     if(isinf(dummyScalar))
       if(!silent) warning("You have a singularity at the origin in your doppler() function.");
   }
 
-  if(!allBitsSet(par->dataFlags, DS_mask_velocity) && par->nLineImages>0){
+  if(!allBitsSet(par->dataFlags, DS_mask_velocity) && doMolCalcs){
     velocity(0.0,0.0,0.0,dummyVel);
     if(isinf(dummyVel[0])||isinf(dummyVel[1])||isinf(dummyVel[2]))
       if(!silent) warning("You have a singularity at the origin in your velocity() function.");
@@ -1351,7 +1352,7 @@ readOrBuildGrid(configInfo *par, struct grid **gp){
     par->dataFlags |= DS_mask_temperatures;
   }
 
-  if(par->nLineImages>0){
+  if(doMolCalcs){
     if(!allBitsSet(par->dataFlags, DS_mask_abundance)){
       /* Means we didn't read abun values from file, we have to calculate them via the user-supplied fuction. */
       dummyPointer = malloc(sizeof(*dummyPointer)*par->nSpecies);
@@ -1382,7 +1383,7 @@ readOrBuildGrid(configInfo *par, struct grid **gp){
     par->dataFlags |= DS_mask_abundance;
   }
 
-  if(!allBitsSet(par->dataFlags, DS_mask_turb_doppler) && par->nLineImages>0){
+  if(!allBitsSet(par->dataFlags, DS_mask_turb_doppler) && doMolCalcs){
     for(i=0;i<par->pIntensity;i++)
       doppler((*gp)[i].x[0],(*gp)[i].x[1],(*gp)[i].x[2],&(*gp)[i].dopb_turb);	
     for(i=par->pIntensity;i<par->ncell;i++)
@@ -1391,7 +1392,7 @@ readOrBuildGrid(configInfo *par, struct grid **gp){
     par->dataFlags |= DS_mask_turb_doppler;
   }
 
-  if(!allBitsSet(par->dataFlags, DS_mask_velocity) && par->nLineImages>0){
+  if(!allBitsSet(par->dataFlags, DS_mask_velocity) && doMolCalcs){
     for(i=0;i<par->pIntensity;i++)
       velocity((*gp)[i].x[0],(*gp)[i].x[1],(*gp)[i].x[2],(*gp)[i].vel);
 

--- a/src/grid.c
+++ b/src/grid.c
@@ -1015,7 +1015,7 @@ void writeGridIfRequired(configInfo *par, struct grid *gp, molData *md){
     }
 
     initializeKeyword(&primaryKwds[0]);
-    primaryKwds[0].datatype = TDOUBLE;
+    primaryKwds[0].datatype = lime_DOUBLE;
     primaryKwds[0].keyname = "RADIUS  ";
     primaryKwds[0].doubleValue = par->radius;
     primaryKwds[0].comment = "[m] Model radius.";
@@ -1059,7 +1059,7 @@ readOrBuildGrid(configInfo *par, struct grid **gp){
     struct keywordType *desiredKwds=malloc(sizeof(struct keywordType)*numDesiredKwds);
 
     initializeKeyword(&desiredKwds[0]);
-    desiredKwds[0].datatype = TDOUBLE;
+    desiredKwds[0].datatype = lime_DOUBLE;
     desiredKwds[0].keyname = "RADIUS  ";
     /* Currently not doing anything with the read keyword. */
 

--- a/src/grid2fits.c
+++ b/src/grid2fits.c
@@ -127,7 +127,7 @@ writeKeywordsToFITS(lime_fptr *fptr, struct keywordType *kwds\
       fits_write_key(fptr, TDOUBLE, kwds[i].keyname, &kwds[i].doubleValue, kwds[i].comment, &status);
     else{
       if(!silent){
-        sprintf(message, "Keyword %d dataype %d is not currently accepted.", i, kwds[i].datatype);
+        sprintf(message, "Keyword %d datatype %d is not currently accepted.", i, kwds[i].datatype);
         bail_out(message);
       }
       exit(1);
@@ -932,7 +932,7 @@ readKeywordsFromFITS(lime_fptr *fptr, struct keywordType *kwds\
       fits_read_key(fptr, TDOUBLE, kwds[i].keyname, &kwds[i].doubleValue, kwds[i].comment, &status);
     else{
       if(!silent){
-        sprintf(message, "Keyword %d dataype %d is not currently accepted.", i, kwds[i].datatype);
+        sprintf(message, "Keyword %d datatype %d is not currently accepted.", i, kwds[i].datatype);
         bail_out(message);
       }
       exit(1);

--- a/src/gridio.c
+++ b/src/gridio.c
@@ -708,7 +708,7 @@ NOTE that gp should not be allocated before this routine is called.
   lime_fptr *fptr;
   int status=0;
   unsigned short i_us, numTables;
-  unsigned int *firstNearNeigh=NULL, totalNumGridPoints, i_ui;
+  unsigned int *firstNearNeigh=NULL, totalNumGridPoints;
   struct linkType *links=NULL, **nnLinks=NULL;
   char message[80];
 
@@ -836,9 +836,6 @@ NOTE that gp should not be allocated before this routine is called.
 
   if(numTables>0){
     (*dataFlags) |= (1 << DS_bit_populations);
-
-    for(i_ui=0;i_ui<totalNumGridPoints;i_ui++)
-      (*gp)[i_ui].mol = malloc(sizeof(struct populations)*gridInfoRead->nSpecies);
 
     gridInfoRead->mols = malloc(sizeof(struct molInfoType)*gridInfoRead->nSpecies);
     for(i_us=0;i_us<gridInfoRead->nSpecies;i_us++){

--- a/src/inpars.h
+++ b/src/inpars.h
@@ -21,7 +21,7 @@ typedef struct {
   char *outputfile,*binoutputfile,*gridfile,*pregrid,*restart,*dust;
   char *gridInFile,**gridOutFiles;
   char **moldatfile,**collPartNames;
-  _Bool resetRNG;
+  _Bool resetRNG,doSolveRTE;
 } inputPars;
 
 /* Image information */

--- a/src/lime.h
+++ b/src/lime.h
@@ -145,7 +145,7 @@ typedef struct {
   char *outputfile,*binoutputfile,*gridfile,*pregrid,*restart,*dust;
   char *gridInFile,**gridOutFiles;
   char **girdatfile,**moldatfile,**collPartNames;
-  _Bool writeGridAtStage[NUM_GRID_STAGES],resetRNG,doInterpolateVels,useAbun;
+  _Bool writeGridAtStage[NUM_GRID_STAGES],resetRNG,doInterpolateVels,useAbun,doSolveRTE;
 } configInfo;
 
 struct cpData {
@@ -388,13 +388,14 @@ void	casaStyleProgressBar(const int, int);
 void	collpartmesg(char*, int);
 void	collpartmesg2(char*);
 void	collpartmesg3(int, int);
-void	goodnight(int, char*);
+void	goodnight(int);
 void	greetings(void);
 void	greetings_parallel(int);
 void	printDone(int);
 void	printMessage(char *);
 void	progressbar(double, int);
 void	progressbar2(configInfo*, int, int, double, double, double);
+void	reportOutput(char*);
 void	quotemass(double);
 void	screenInfo(void);
 void	warning(char*);

--- a/src/main.c
+++ b/src/main.c
@@ -89,6 +89,7 @@ initParImg(inputPars *par, image **img)
   par->nSolveIters=17;
   par->traceRayAlgorithm=0;
   par->resetRNG=0;
+  par->doSolveRTE=0;
 
   par->gridOutFiles = malloc(sizeof(char *)*NUM_GRID_STAGES);
   for(i=0;i<NUM_GRID_STAGES;i++)
@@ -123,11 +124,6 @@ initParImg(inputPars *par, image **img)
   nImages=0;
   while((*img)[nImages].filename!=NULL && nImages<MAX_NIMAGES)
     nImages++;
-
-  if(nImages==0) {
-    if(!silent) bail_out("No images defined (or you haven't set the 1st filename).");
-    exit(1);
-  }
 
   /* Set img defaults. */
   for(i=0;i<nImages;i++) {
@@ -216,7 +212,7 @@ run(inputPars inpars, image *inimg, const int nImages){
     }
   }
 
-  if(par.nLineImages>0){
+  if(par.nLineImages>0 || par.doSolveRTE){
     molInit(&par, md);
 
     for(gi=0;gi<par.ncell;gi++){
@@ -248,8 +244,11 @@ run(inputPars inpars, image *inimg, const int nImages){
       }
     }
   }
-  
-  if(!silent) goodnight(initime,img[0].filename);
+
+  if(!silent){
+    if(par.nImages>0) reportOutput(img[0].filename);
+    goodnight(initime);
+  }
 
   freeGrid((unsigned int)par.ncell, (unsigned short)par.nSpecies, gp);
   freeMolData(par.nSpecies, md);

--- a/src/messages.c
+++ b/src/messages.c
@@ -224,15 +224,23 @@ void casaStyleProgressBar(const int maxI, int i){
 }
 
 void
-goodnight(int initime, char filename[80]){
-  int runtime=time(0)-initime;
+reportOutput(char filename[80]){
 #ifdef NO_NCURSES
   printf("Output written to %s\n", filename);
+#else
+  move(14,4); printw("Output written to %s", filename);
+  refresh();
+#endif
+}
+
+void
+goodnight(int initime){
+  int runtime=time(0)-initime;
+#ifdef NO_NCURSES
   printf("*** Program ended successfully               \n");
   printf("    Runtime: %3dh %2dm %2ds\n\n", runtime / 3600, runtime / 60 % 60, runtime % 60);
 
 #else
-  move(14,4); printw("Output written to %s", filename);
   move(22,0); printw("*** Program ended successfully               ");
   move(22,58); printw("runtime: %3dh %2dm %2ds", runtime/3600, runtime/60%60, runtime%60);
   move(23,0); printw("*** [Press any key to quit]");


### PR DESCRIPTION
This allows the user to run LIME with zero images specified, and thus introduces the facility to run LIME in two separate sessions (desirable for CASA integration): the first to solve the RTE and save the results to file, the second to read the file and create raytraced images from it. A new parameter `par.doSolveRTE` has been added to compensate for the loss of information when zero images are specified.