### PR TITLE
Changes to make it easier to split solving from raytracing (looking ahead to the CASA interface).

### DIFF
--- a/src/grid_aux.c
+++ b/src/grid_aux.c
@@ -516,7 +516,7 @@ getEdgeVelocities(configInfo *par, struct grid *gp){
 
 /*....................................................................*/
 int setupAndWriteGrid(configInfo *par, struct grid *gp, molData *md, char *outFileName){
-  const int numKwds=2;
+  const int numKwds=3;
   int i,status = 0;
   struct gridInfoType gridInfo;
   unsigned short i_us;
@@ -548,7 +548,14 @@ int setupAndWriteGrid(configInfo *par, struct grid *gp, molData *md, char *outFi
   primaryKwds[i].doubleValue = par->radius;
   sprintf(primaryKwds[i].comment, "[m] Model radius.");
 
-  i = 1;
+  i++;
+  initializeKeyword(&primaryKwds[i]);
+  primaryKwds[i].datatype = lime_DOUBLE;
+  sprintf(primaryKwds[i].keyname, "MINSCALE");
+  primaryKwds[i].doubleValue = par->minScale;
+  sprintf(primaryKwds[i].comment, "[m] Minimum model scale.");
+
+  i++;
   initializeKeyword(&primaryKwds[i]);
   primaryKwds[i].datatype = lime_INT;
   sprintf(primaryKwds[i].keyname, "NSOLITER");

--- a/src/main.c
+++ b/src/main.c
@@ -15,12 +15,6 @@ int silent = 1;
 int silent = 0;
 #endif
 
-#ifdef TEST
-_Bool fixRandomSeeds = TRUE;
-#else
-_Bool fixRandomSeeds = FALSE;
-#endif
-
 /*....................................................................*/
 int
 initParImg(inputPars *par, image **img)
@@ -74,7 +68,7 @@ initParImg(inputPars *par, image **img)
   par->antialias=1;
   par->polarization=0;
   par->nThreads = NTHREADS;
-  par->nSolveIters=17;
+  par->nSolveIters=0;
   par->traceRayAlgorithm=0;
   par->resetRNG=0;
   par->doSolveRTE=0;

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -922,9 +922,6 @@ At the moment I will fix the number of segments, but it might possibly be faster
 
     entryI = exitI;
     exitI = 1 - exitI;
-
-//if(ci>210) exit(1);
-//if(ci>=2) exit(1);
   } /* End loop over cells in the chain traversed by the ray. */
 
   if(img[im].doline && img[im].doInterpolateVels)

--- a/src/writefits.c
+++ b/src/writefits.c
@@ -135,8 +135,6 @@ write3Dfits(int im, int unit_index, configInfo *par, imageInfo *img){
   fits_close_file(fptr, &status);
 
   free(row);
-
-  if(!silent) printDone(13);
 }
 
 void 
@@ -263,8 +261,6 @@ write2Dfits(int im, int unit_index, configInfo *par, imageInfo *img){
   fits_close_file(fptr, &status);
 
   free(row);
-
-  if(!silent) printDone(13);
 }
 
 void writeFits(const int i, const int unit_index, configInfo *par, imageInfo *img){


### PR DESCRIPTION
  - Numbers of grid points, radius and minScale are now read from a grid file if one is provided. The associated parameters are no longer mandatory.

  - MINSCALE keyword/attribute is now written to and read from grid files.

  - Global fixRandomSeeds is now set in the header of run.c, not main.c as before.

  - The par->nSolveIters default has been changed to 0 to get rid of warning when LTE mode chosen.

  - Function parseInput() has been rearranged a little, mostly for the sake of neatness.

  - Duplicated printDone(13) call removed from write2Dfits() and write3Dfits().